### PR TITLE
Aggregate allocations between polling intervals to catch OOMs

### DIFF
--- a/src-win/shmem-detect.c
+++ b/src-win/shmem-detect.c
@@ -1,4 +1,5 @@
 #include "plat.h"
+#include "aimdo-time.h"
 
 #include <windows.h>
 #include <dxgi1_4.h>
@@ -64,12 +65,20 @@ fail:
 #define WDDM_BUDGET_HEADROOM (512 * 1024 * 1024)
 #define CUDA_BUDGET_HEADROOM (192 * 1024 * 1024)
 
-size_t wddm_budget_deficit(int device, size_t bytes)
+bool poll_budget_deficit()
 {
     DXGI_QUERY_VIDEO_MEMORY_INFO info;
     uint64_t effective_budget = vram_capacity;
-    ssize_t deficit;
     size_t free_vram = 0, total_vram = 0;
+
+    uint64_t now = GET_TICK();
+    static uint64_t last_check = 0;
+
+    if (now - last_check < 2000) {
+        return true;
+    }
+    last_check = now;
+    total_vram_last_check = total_vram_usage;
 
     if (G_WDDM.adapter) {
         if (SUCCEEDED(G_WDDM.adapter->lpVtbl->QueryVideoMemoryInfo(G_WDDM.adapter, 0, DXGI_MEMORY_SEGMENT_GROUP_LOCAL, &info))) {
@@ -79,23 +88,19 @@ size_t wddm_budget_deficit(int device, size_t bytes)
         }
     }
 
-    deficit = (ssize_t)(total_vram_usage + bytes + WDDM_BUDGET_HEADROOM) - (ssize_t)effective_budget;
-
-    if (deficit > 0) {
-        log(DEBUG, "Imminent WDDM VRAM OOM detected. Budget: %llu MB, Request: %zu MB, Deficit: %zd MB\n",
-            effective_budget / (1024 * 1024), bytes / (1024 * 1024), deficit / (1024 * 1024));
-    }
+    deficit_sync = (ssize_t)(total_vram_usage + WDDM_BUDGET_HEADROOM) - (ssize_t)effective_budget;
+    prevailing_deficit_method = "WDDM budget";
 
     if (CHECK_CU(cuMemGetInfo(&free_vram, &total_vram))) {
-        ssize_t deficit_cuda = (ssize_t)(CUDA_BUDGET_HEADROOM / 2 + bytes) - free_vram;
+        ssize_t deficit_cuda = (ssize_t)(CUDA_BUDGET_HEADROOM / 2) - (ssize_t)free_vram;
 
-        if (deficit_cuda > 0 && deficit_cuda > deficit) {
-            deficit = deficit_cuda;
-            log(DEBUG, "Cuda detected VRAM OOM. Request %zu MB, Deficit: %zd MB\n", bytes / (1024 * 1024), deficit / (1024 * 1024));
+        if (deficit_cuda > deficit_sync) {
+            deficit_sync = deficit_cuda;
+            prevailing_deficit_method = "cuMemGetInfo (Windows)";
         }
     }
 
-    return (deficit > 0) ? (size_t)deficit : 0;
+    return true;
 }
 
 void aimdo_wddm_cleanup()

--- a/src/aimdo-time.h
+++ b/src/aimdo-time.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifdef _WIN32
+#include <windows.h>
+#define GET_TICK() GetTickCount64()
+#else
+#include <sys/time.h>
+static inline uint64_t get_tick_linux() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+#define GET_TICK() get_tick_linux()
+#endif

--- a/src/control.c
+++ b/src/control.c
@@ -1,28 +1,29 @@
 #include "plat.h"
+#include "aimdo-time.h"
 
 uint64_t vram_capacity;
 uint64_t total_vram_usage;
+uint64_t total_vram_last_check;
+ssize_t deficit_sync;
+const char *prevailing_deficit_method;
 
-#define VRAM_HEADROOM (256 * 1024 * 1024)
+bool cuda_budget_deficit() {
+    uint64_t now = GET_TICK();
+    static uint64_t last_check = 0;
+    size_t free_vram = 0;
+    size_t total_vram = 0;
 
-size_t cuda_budget_deficit(int device, size_t bytes) {
-    size_t free_vram = 0, total_vram = 0;
-
-    ssize_t deficit = (ssize_t)(total_vram_usage + bytes + VRAM_HEADROOM) - vram_capacity;
-
-    if (CHECK_CU(cuMemGetInfo(&free_vram, &total_vram))) {
-        ssize_t deficit_cuda = (ssize_t)(VRAM_HEADROOM + bytes) - free_vram;
-
-        if (deficit_cuda > deficit) {
-            deficit = deficit_cuda;
-        }
+    if (now - last_check < 2000) {
+        return true;
     }
-
-    if (deficit > 0) {
-        log(DEBUG, "Imminent VRAM OOM detected. Deficit: %zd MB\n", deficit / (1024 * 1024));
+    last_check = now;
+    total_vram_last_check = total_vram_usage;
+    if (!CHECK_CU(cuMemGetInfo(&free_vram, &total_vram))) {
+        return false;
     }
-
-    return (deficit > 0) ? (size_t)deficit : 0;
+    deficit_sync = (ssize_t)VRAM_HEADROOM - (ssize_t)free_vram;
+    prevailing_deficit_method = "cuMemGetInfo";
+    return true;
 }
 
 SHARED_EXPORT

--- a/src/model-vbar.c
+++ b/src/model-vbar.c
@@ -276,6 +276,12 @@ int vbar_fault(void *vbar, uint64_t offset, uint64_t size, uint32_t *signature) 
     log(VVERBOSE, "%s (start): offset=%lldk, size=%lldk\n", __func__, (ull)(offset / K), (ull)(size / K));
     vbars_dirty = true;
 
+    /* Stopgap. If the we get a bad shared memory spike, collect it here on the next layer
+     * as the allocator is unreliable as it may not actually be called reliably when you
+     * really need to know you have spilled.
+     */
+    vbars_free(budget_deficit(0));
+
     if (page_end > mv->watermark) {
         log(VVERBOSE, "VBAR Allocation is above watermark\n");
         return VBAR_FAULT_OOM;
@@ -293,7 +299,7 @@ int vbar_fault(void *vbar, uint64_t offset, uint64_t size, uint32_t *signature) 
 
         log(VERBOSE, "VBAR needs to allocate VRAM for page %d\n", (int)page_nr);
 
-        if (wddm_budget_deficit(mv->device, VBAR_PAGE_SIZE) ||
+        if (budget_deficit(VBAR_PAGE_SIZE) ||
             (err = three_stooges(vaddr, VBAR_PAGE_SIZE, mv->device, &rp->handle)) != CUDA_SUCCESS) {
             if (err != CUDA_ERROR_OUT_OF_MEMORY) {
                 log(ERROR, "VRAM Allocation failed (non OOM)\n");

--- a/src/plat.h
+++ b/src/plat.h
@@ -18,7 +18,7 @@ typedef struct CUstream_st *cudaStream_t;
 #include <assert.h>
 
 /* control.c */
-size_t cuda_budget_deficit(int device, size_t bytes);
+bool cuda_budget_deficit();
 
 #if defined(_WIN32) || defined(_WIN64)
 
@@ -31,11 +31,10 @@ typedef SSIZE_T ssize_t;
 /* shmem-detect.c */
 bool aimdo_wddm_init(CUdevice dev);
 void aimdo_wddm_cleanup();
+bool poll_budget_deficit();
 /* cuda-detour.c */
 bool aimdo_setup_hooks();
 void aimdo_teardown_hooks();
-
-size_t wddm_budget_deficit(int device, size_t bytes);
 
 #else
 
@@ -50,8 +49,8 @@ static inline void aimdo_wddm_cleanup() {}
 static inline bool aimdo_setup_hooks() { return true; }
 static inline void aimdo_teardown_hooks() {}
 
-static inline size_t wddm_budget_deficit(int device, size_t bytes) {
-    return cuda_budget_deficit(device, bytes);
+static inline bool poll_budget_deficit() {
+    return cuda_budget_deficit();
 }
 
 #endif
@@ -65,9 +64,13 @@ static inline void plat_cleanup() {
     aimdo_teardown_hooks();
 }
 
+#define MAX(a, b) (((a) > (b)) ? (a) : (b))
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
 typedef unsigned long long ull;
 #define K 1024
 #define M (K * K)
+#define G (M * K)
 
 enum DebugLevels {
     __NONE__ = -1,
@@ -101,9 +104,31 @@ void log_reset_shots();
 #define log(level, ...) do_log(false, level, __VA_ARGS__)
 #define log_shot(level, ...) do_log(true, level, __VA_ARGS__)
 
+/* The default VRAM headroom. Different deficit methods with BYO headroom */
+#define VRAM_HEADROOM (256 * 1024 * 1024)
+
 /* control.c */
 extern uint64_t vram_capacity;
 extern uint64_t total_vram_usage;
+extern uint64_t total_vram_last_check;
+extern ssize_t deficit_sync;
+extern const char *prevailing_deficit_method;
+
+static inline size_t budget_deficit(size_t size) {
+    ssize_t deficit_simple, deficit_delta;
+    size_t deficit;
+
+    poll_budget_deficit();
+    deficit_simple = (ssize_t)(total_vram_usage + VRAM_HEADROOM + size) - (ssize_t)vram_capacity;
+    deficit_delta = deficit_sync + (ssize_t)total_vram_usage - (ssize_t)total_vram_last_check + size;
+    deficit = (size_t)MAX(MAX(deficit_simple, deficit_delta), (ssize_t)0);
+    if (deficit) {
+        log(DEBUG, "%s: Prevailing Method: %s Deficit: %zu Alloc Size %zu\n", __func__,
+            deficit_simple > deficit_delta ? "simple" : prevailing_deficit_method,
+            deficit / M, size / M);
+    }
+    return deficit;
+}
 
 static inline int check_cu_impl(CUresult res, const char *label) {
     if (res != CUDA_SUCCESS && res != CUDA_ERROR_OUT_OF_MEMORY) {

--- a/src/pyt-cu-plug-alloc-async.c
+++ b/src/pyt-cu-plug-alloc-async.c
@@ -1,18 +1,5 @@
 #include "plat.h"
 
-#ifdef _WIN32
-#include <windows.h>
-#define GET_TICK() GetTickCount64()
-#else
-#include <sys/time.h>
-static inline uint64_t get_tick_linux() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    return (uint64_t)tv.tv_sec * 1000 + tv.tv_usec / 1000;
-}
-#define GET_TICK() get_tick_linux()
-#endif
-
 #define CUDA_PAGE_SIZE (2 << 20)
 #define ALIGN_UP(s) (((s) + CUDA_PAGE_SIZE - 1) & ~(CUDA_PAGE_SIZE - 1))
 #define SIZE_HASH_SIZE 1024
@@ -31,8 +18,6 @@ static inline unsigned int size_hash(CUdeviceptr ptr) {
 
 int aimdo_cuda_malloc_async(CUdeviceptr *devPtr, size_t size, CUstream hStream,
                             int (*true_cuMemAllocAsync)(CUdeviceptr*, size_t, CUstream)) {
-    static uint64_t last_check = 0;
-    uint64_t now = GET_TICK();
     CUdeviceptr dptr;
     CUresult status = 0;
 
@@ -42,14 +27,7 @@ int aimdo_cuda_malloc_async(CUdeviceptr *devPtr, size_t size, CUstream hStream,
         return 1;
     }
 
-    if (now - last_check >= 2000) {
-        last_check = now;
-        CUdevice device;
-        if (!CHECK_CU(cuCtxGetDevice(&device))) {
-            return 1;
-        }
-        vbars_free(wddm_budget_deficit(device, size));
-    }
+    vbars_free(budget_deficit(size));
 
     if (CHECK_CU(true_cuMemAllocAsync(&dptr, size, hStream))) {
         *devPtr = dptr;

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -43,7 +43,7 @@ bool vrambuf_grow(void *arg, size_t required_size) {
         grow_to = buf->max_size;
     }
 
-    vbars_free(wddm_budget_deficit(buf->device, grow_to - buf->allocated));
+    vbars_free(budget_deficit(grow_to - buf->allocated));
     while (buf->allocated < grow_to) {
         size_t to_allocate = grow_to - buf->allocated;
         if (to_allocate > VRAM_CHUNK_SIZE) {


### PR DESCRIPTION
Budget deficit detection now polls platform state every 2s and tracks allocation deltas between polls, catching OOMs that were previously missed between sync points.

### Contribution Agreement
- [ X ] I agree that my contributions are licensed under the GPLv3.
- [ X ] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
