### PR TITLE
Add per-page residency introspection API

### DIFF
--- a/comfy_aimdo/model_vbar.py
+++ b/comfy_aimdo/model_vbar.py
@@ -36,6 +36,14 @@ if lib is not None:
     lib.vbars_analyze.argtypes = [ctypes.c_bool]
     lib.vbars_analyze.restype = ctypes.c_uint64
 
+    lib.vbar_get_nr_pages.argtypes = [ctypes.c_void_p]
+    lib.vbar_get_nr_pages.restype = ctypes.c_size_t
+
+    lib.vbar_get_watermark.argtypes = [ctypes.c_void_p]
+    lib.vbar_get_watermark.restype = ctypes.c_size_t
+
+    lib.vbar_get_residency.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_uint8), ctypes.c_size_t]
+
 class ModelVBAR:
     def __init__(self, size, device):
         self._ptr = lib.vbar_allocate(int(size), device)
@@ -92,6 +100,22 @@ class ModelVBAR:
 
     def free_memory(self, size_bytes):
         return lib.vbar_free_memory(self._ptr, int(size_bytes))
+
+    def get_nr_pages(self):
+        return lib.vbar_get_nr_pages(self._ptr)
+
+    def get_watermark(self):
+        return lib.vbar_get_watermark(self._ptr)
+
+    def get_residency(self):
+        """Returns a list of per-page status flags.
+        Bit 0 (& 1): resident in VRAM
+        Bit 1 (& 2): pinned
+        """
+        nr_pages = self.get_nr_pages()
+        buf = (ctypes.c_uint8 * nr_pages)()
+        lib.vbar_get_residency(self._ptr, buf, nr_pages)
+        return list(buf)
 
     def __del__(self):
         if hasattr(self, '_ptr') and self._ptr:

--- a/src/model-vbar.c
+++ b/src/model-vbar.c
@@ -376,6 +376,29 @@ size_t vbar_loaded_size(void *vbar) {
 }
 
 SHARED_EXPORT
+size_t vbar_get_nr_pages(void *vbar) {
+    ModelVBAR *mv = (ModelVBAR *)vbar;
+    return mv->nr_pages;
+}
+
+SHARED_EXPORT
+size_t vbar_get_watermark(void *vbar) {
+    ModelVBAR *mv = (ModelVBAR *)vbar;
+    return mv->watermark;
+}
+
+SHARED_EXPORT
+void vbar_get_residency(void *vbar, uint8_t *out, size_t max_pages) {
+    ModelVBAR *mv = (ModelVBAR *)vbar;
+    size_t n = mv->nr_pages < max_pages ? mv->nr_pages : max_pages;
+    for (size_t i = 0; i < n; i++) {
+        ResidentPage *rp = &mv->residency_map[i];
+        /* bit 0: resident, bit 1: pinned */
+        out[i] = (rp->handle ? 1 : 0) | (rp->pinned ? 2 : 0);
+    }
+}
+
+SHARED_EXPORT
 uint64_t vbar_free_memory(void *vbar, uint64_t size) {
     ModelVBAR *mv = (ModelVBAR *)vbar;
     size_t pages_to_free = VBAR_GET_PAGE_NR_UP(size);


### PR DESCRIPTION
Add three new exported functions to query VBAR state:
- vbar_get_nr_pages: total number of 32MB pages
- vbar_get_watermark: current watermark position
- vbar_get_residency: per-page bitmap (resident/pinned flags)

These are read-only queries with no CUDA synchronization, intended for tooling and visualization of dynamic VRAM state.

### Contribution Agreement
- [X] I agree that my contributions are licensed under the GPLv3.
- [X] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
