### PR TITLE
linux: stop exporting cudaMalloc/cudaFree symbols

### DIFF
--- a/src/plat.h
+++ b/src/plat.h
@@ -40,9 +40,11 @@ void aimdo_teardown_hooks();
 
 #define SHARED_EXPORT
 
-/* On Linux we are the apparent implementation of cudart */
-#define aimdo_cuda_malloc cudaMalloc
-#define aimdo_cuda_free cudaFree
+/* On Linux, only intercept async allocations (cudaMallocAsync/cudaFreeAsync).
+ * Do NOT export cudaMalloc/cudaFree — the non-async path uses virtual memory
+ * (vrambuf) which is incompatible with extensions that mix real cudaMalloc
+ * allocations with aimdo's virtual memory in the same CUDA context.
+ */
 
 static inline bool aimdo_wddm_init(CUdevice dev) { return true; }
 static inline void aimdo_wddm_cleanup() {}


### PR DESCRIPTION
Third-party CUDA extensions (e.g. cumesh) that call cudaMalloc are currently being silently redirected to vrambuf virtual memory, causing CUDA error 700 (illegal memory access) when their kernels run.

Here's a little example:

```
    File "/home/work/trellis2-vb/ComfyUI/execution.py", line 295, in process_inputs                                                                                                   
      result = f(**inputs)                                                                                                                                                            
    File ".../vb_nodes.py", line 1619, in process                                                                                                                                     
      cumesh.init(*CuMesh.remeshing.remesh_narrow_band_dc_quad(                                                                                                                       
    File ".../cumesh_vb/remeshing.py", line 787, in remesh_narrow_band_dc_quad                                                                                                        
      grid_verts = _C.get_sparse_voxel_grid_active_vertices(                                                                                                                          
  RuntimeError: [CuMesh] CUDA error:                                                                                                                                                  
      File:       .../svox2vert.cu                                                                                                                                                    
      Line:       184                                                                                                                                                                 
      Error code: 700                                                                                                                                                                 
      Error text: an illegal memory access was encountered                                                                                                                            

```

This means a lot of people using nodes with CUDA packages are using --disable-dynamic-vram.

Removing #define aimdo_cuda_malloc cudaMalloc / aimdo_cuda_free cudaFree on Linux fixes this, without affecting DynamicVRAM (alloc_fn/free_fn, cudaMallocAsync/cudaFreeAsync, and VBAR model weight paging are all unchanged)

As far as I understand, VRAM pressure is still detected via cuMemGetInfo polling in budget_deficit()