### PR TITLE
allocators: Dont use the VMA allocator for cuda_malloc

### DIFF
--- a/src-win/cuda-detour.c
+++ b/src-win/cuda-detour.c
@@ -15,11 +15,11 @@ static int (*true_cuMemAllocAsync)(CUdeviceptr*, size_t, CUstream);
 static int (*true_cuMemFreeAsync)(CUdeviceptr, CUstream);
 
 static int aimdo_cuMemAlloc_v2(CUdeviceptr* dptr, size_t size) {
-    return aimdo_cuda_malloc(dptr, size);
+    return aimdo_cuda_malloc(dptr, size, true_cuMemAlloc_v2);
 }
 
 static int aimdo_cuMemFree_v2(CUdeviceptr dptr) {
-    return aimdo_cuda_free(dptr);
+    return aimdo_cuda_free(dptr, true_cuMemFree_v2);
 }
 
 static int aimdo_cuMemAllocAsync(CUdeviceptr* dptr, size_t size, CUstream hStream) {

--- a/src/plat.h
+++ b/src/plat.h
@@ -40,10 +40,6 @@ void aimdo_teardown_hooks();
 
 #define SHARED_EXPORT
 
-/* On Linux we are the apparent implementation of cudart */
-#define aimdo_cuda_malloc cudaMalloc
-#define aimdo_cuda_free cudaFree
-
 static inline bool aimdo_wddm_init(CUdevice dev) { return true; }
 static inline void aimdo_wddm_cleanup() {}
 static inline bool aimdo_setup_hooks() { return true; }
@@ -194,8 +190,10 @@ SHARED_EXPORT
 uint64_t vbars_analyze(bool only_dirty);
 
 /* pyt-cu-alloc.c */
-int aimdo_cuda_malloc(CUdeviceptr *dptr, size_t size);
-int aimdo_cuda_free(CUdeviceptr dptr);
+int aimdo_cuda_malloc(CUdeviceptr *dptr, size_t size,
+                      int (*true_cuMemAlloc_v2)(CUdeviceptr*, size_t));
+int aimdo_cuda_free(CUdeviceptr dptr,
+                    int (*true_cuMemFree_v2)(CUdeviceptr));
 
 int aimdo_cuda_malloc_async(CUdeviceptr *devPtr, size_t size, CUstream hStream,
                             int (*true_cuMemAllocAsync)(CUdeviceptr*, size_t, CUstream));

--- a/src/pyt-cu-plug-alloc-async.c
+++ b/src/pyt-cu-plug-alloc-async.c
@@ -1,6 +1,10 @@
 #include "plat.h"
 
 #define SIZE_HASH_SIZE 1024
+/* cudaMalloc does not guarantee fragmentation handling as well as cudaMallocAsync,
+ * so we reserve a small extra headroom when forcing budget pressure.
+ */
+#define CUDA_MALLOC_HEADROOM (128 * M)
 
 typedef struct SizeEntry {
     CUdeviceptr ptr;
@@ -35,6 +39,100 @@ static inline void st_lock(void) { pthread_mutex_lock(&size_table_lock); }
 static inline void st_unlock(void) { pthread_mutex_unlock(&size_table_lock); }
 #endif
 
+static inline void account_alloc(CUdeviceptr ptr, size_t size) {
+    unsigned int h = size_hash(ptr);
+    SizeEntry *entry;
+
+    st_lock();
+    total_vram_usage += CUDA_ALIGN_UP(size);
+
+    entry = (SizeEntry *)malloc(sizeof(*entry));
+    if (entry) {
+        entry->ptr = ptr;
+        entry->size = size;
+        entry->next = size_table[h];
+        size_table[h] = entry;
+    }
+    st_unlock();
+}
+
+static inline void account_free(CUdeviceptr ptr, CUstream hStream) {
+    SizeEntry *entry;
+    SizeEntry **prev;
+    unsigned int h = size_hash(ptr);
+
+    st_lock();
+    entry = size_table[h];
+    prev = &size_table[h];
+
+    while (entry) {
+        if (entry->ptr == ptr) {
+            *prev = entry->next;
+
+            log(VVERBOSE, "Freed: ptr=0x%llx, size=%zuk, stream=%p\n", ptr, entry->size / K, hStream);
+            total_vram_usage -= CUDA_ALIGN_UP(entry->size);
+
+            st_unlock();
+            free(entry);
+            return;
+        }
+        prev = &entry->next;
+        entry = entry->next;
+    }
+    st_unlock();
+
+    log(ERROR, "%s: could not account free at %p\n", __func__, ptr);
+}
+
+int aimdo_cuda_malloc(CUdeviceptr *devPtr, size_t size,
+                      int (*true_cuMemAlloc_v2)(CUdeviceptr*, size_t)) {
+    CUdeviceptr dptr;
+    CUresult status = 0;
+
+    if (!devPtr || !true_cuMemAlloc_v2) {
+        return 1;
+    }
+
+    vbars_free(budget_deficit(size + CUDA_MALLOC_HEADROOM));
+
+    if (CHECK_CU(true_cuMemAlloc_v2(&dptr, size))) {
+        *devPtr = dptr;
+        account_alloc(*devPtr, size);
+        return 0;
+    }
+
+    vbars_free(size + CUDA_MALLOC_HEADROOM);
+    status = true_cuMemAlloc_v2(&dptr, size);
+    if (CHECK_CU(status)) {
+        *devPtr = dptr;
+        account_alloc(*devPtr, size);
+        return 0;
+    }
+
+    *devPtr = 0;
+    return status;
+}
+
+int aimdo_cuda_free(CUdeviceptr devPtr,
+                    int (*true_cuMemFree_v2)(CUdeviceptr)) {
+    CUresult status;
+
+    if (!devPtr) {
+        return 0;
+    }
+    if (!true_cuMemFree_v2) {
+        return 1;
+    }
+
+    status = true_cuMemFree_v2(devPtr);
+    if (!CHECK_CU(status)) {
+        return status;
+    }
+
+    account_free(devPtr, NULL);
+    return status;
+}
+
 int aimdo_cuda_malloc_async(CUdeviceptr *devPtr, size_t size, CUstream hStream,
                             int (*true_cuMemAllocAsync)(CUdeviceptr*, size_t, CUstream)) {
     CUdeviceptr dptr;
@@ -63,21 +161,7 @@ int aimdo_cuda_malloc_async(CUdeviceptr *devPtr, size_t size, CUstream hStream,
     return status; /* Fail */
 
 success:
-
-    st_lock();
-    total_vram_usage += CUDA_ALIGN_UP(size);
-
-    {
-        unsigned int h = size_hash(*devPtr);
-        SizeEntry *entry = (SizeEntry *)malloc(sizeof(*entry));
-        if (entry) {
-            entry->ptr = *devPtr;
-            entry->size = size;
-            entry->next = size_table[h];
-            size_table[h] = entry;
-        }
-    }
-    st_unlock();
+    account_alloc(*devPtr, size);
 
     log(VVERBOSE, "%s (return): ptr=%p\n", __func__, *devPtr);
     return 0;
@@ -85,9 +169,6 @@ success:
 
 int aimdo_cuda_free_async(CUdeviceptr devPtr, CUstream hStream,
                           int (*true_cuMemFreeAsync)(CUdeviceptr, CUstream)) {
-    SizeEntry *entry;
-    SizeEntry **prev;
-    unsigned int h;
     CUresult status;
 
     log(VVERBOSE, "%s (start) ptr=%p\n", __func__, devPtr);
@@ -96,32 +177,13 @@ int aimdo_cuda_free_async(CUdeviceptr devPtr, CUstream hStream,
         return 0;
     }
 
-    st_lock();
-    h = size_hash(devPtr);
-    entry = size_table[h];
-    prev = &size_table[h];
-
-    while (entry) {
-        if (entry->ptr == devPtr) {
-            *prev = entry->next;
-
-            log(VVERBOSE, "Freed: ptr=0x%llx, size=%zuk, stream=%p\n", devPtr, entry->size / K, hStream);
-            status = true_cuMemFreeAsync(devPtr, hStream);
-            if (CHECK_CU(status)) {
-                total_vram_usage -= CUDA_ALIGN_UP(entry->size);
-            }
-
-            st_unlock();
-            free(entry);
-            return status;
-        }
-        prev = &entry->next;
-        entry = entry->next;
+    status = true_cuMemFreeAsync(devPtr, hStream);
+    if (!CHECK_CU(status)) {
+        return status;
     }
-    st_unlock();
 
-    log(ERROR, "%s: could not account free at %p\n", __func__, devPtr);
-    return true_cuMemFreeAsync(devPtr, hStream);
+    account_free(devPtr, hStream);
+    return status;
 }
 
 #if !defined(_WIN32) && !defined(_WIN64)
@@ -132,6 +194,21 @@ static inline void ensure_ctx(void) {
     if (cuCtxGetCurrent(&ctx) != CUDA_SUCCESS || !ctx) {
         cuCtxSetCurrent(aimdo_cuda_ctx);
     }
+}
+
+cudaError_t cudaMalloc(void** devPtr, size_t size) {
+    if (!devPtr) {
+        return 1; /* cudaErrorInvalidValue */
+    }
+
+    ensure_ctx();
+    return aimdo_cuda_malloc((CUdeviceptr*)devPtr, size, cuMemAlloc_v2) ?
+                2 /* cudaErrorMemoryAllocation */ : 0;
+}
+
+cudaError_t cudaFree(void* devPtr) {
+    ensure_ctx();
+    return (cudaError_t)aimdo_cuda_free((CUdeviceptr)devPtr, cuMemFree_v2);
 }
 
 cudaError_t cudaMallocAsync(void** devPtr, size_t size, cudaStream_t stream) {

--- a/src/pyt-cu-plug-alloc.c
+++ b/src/pyt-cu-plug-alloc.c
@@ -60,19 +60,6 @@ void *alloc_fn(size_t size, int device, cudaStream_t stream) {
     return (void *)vrambuf_get(entry);
 }
 
-int aimdo_cuda_malloc(CUdeviceptr *dev_ptr, size_t size) {
-    int device;
-    if (!dev_ptr) {
-        return 1; /* cudaErrorInvalidValue */
-    }
-    if (!CHECK_CU(cuCtxGetDevice(&device))) {
-        return 101; /* cudaErrorInvalidDevice */
-    }
-
-    *dev_ptr = (CUdeviceptr)alloc_fn(size, device, NULL);
-    return *dev_ptr ? 0 /* cudaSuccess */ : 2 /* cudaErrorMemoryAllocation */;
-}
-
 SHARED_EXPORT
 void free_fn(void* ptr, size_t size, int device, cudaStream_t stream) {
     log_shot(DEBUG, "Pytorch is freeing VRAM ...\n");
@@ -94,13 +81,4 @@ void free_fn(void* ptr, size_t size, int device, cudaStream_t stream) {
     }
 
     log(ERROR, "%s could not find VRAM@%p\n", __func__, ptr);
-}
-
-int aimdo_cuda_free(CUdeviceptr dev_ptr) {
-    int device;
-    if (!CHECK_CU(cuCtxGetDevice(&device))) {
-        return 101; /* cudaErrorInvalidDevice */
-    }
-    free_fn((void *)dev_ptr, 0, device, NULL);
-    return 0;
 }


### PR DESCRIPTION
This has some closed-source synchronization semantics so its actually impossible to self implement safely. Its subject to more fragmentation than the main allocator, but just add a little bit of extra headroom. Rejig the code to make the linux wrappers the same as for the async allocators.

### Contribution Agreement
- [ X ] I agree that my contributions are licensed under the GPLv3.
- [ X ] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).

Example Test Conditions:

This test case (vibe code): 
[foo.py](https://github.com/user-attachments/files/25905435/foo.py)

Before:

```
(venv) rattus@rattus-box2:~$ pip install comfy-aimdo --force-reinstall
Collecting comfy-aimdo
  Using cached comfy_aimdo-0.2.9-cp39-abi3-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl.metadata (4.2 kB)
Using cached comfy_aimdo-0.2.9-cp39-abi3-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl (82 kB)
Installing collected packages: comfy-aimdo
  Attempting uninstall: comfy-aimdo
    Found existing installation: comfy-aimdo 0.2.9
    Uninstalling comfy-aimdo-0.2.9:
      Successfully uninstalled comfy-aimdo-0.2.9
Successfully installed comfy-aimdo-0.2.9
(venv) rattus@rattus-box2:~$ python ./foo.py 
aimdo: src/control.c:68:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce GTX 1660 SUPER (VRAM: 5746 MB)
using aimdo cudaMalloc @ 0x77beb4f90000
using aimdo cudaFree   @ 0x77beb4f90400
free=4879 MiB, test_size=3072 MiB
aimdo: src/pyt-cu-plug-alloc.c:42:VERBOSE:alloc_fn (start): size=3145728k, device=0
aimdo: src/pyt-cu-plug-alloc.c:59:VERBOSE:alloc_fn (return): ptr=0x302000000
aimdo: src/pyt-cu-plug-alloc.c:78:DEBUG:Pytorch is freeing VRAM ...
aimdo: src/pyt-cu-plug-alloc.c:79:VERBOSE:free_fn (start) ptr=0x302000000 size=0k, device=0
aimdo: src/pyt-cu-plug-alloc.c:92:VERBOSE:Freed: ptr=0x302000000, size=0k, stream=(nil)
FAIL sync iter=0, free_ms=7.464: rc=700 (an illegal memory access was encountered)
```

After:

```
(venv) rattus@rattus-box2:~$ pip install ~/Downloads/wheels-ubuntu-latest/comfy_aimdo-0.2.10.dev1-cp39-abi3-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl 
Processing ./Downloads/wheels-ubuntu-latest/comfy_aimdo-0.2.10.dev1-cp39-abi3-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
Installing collected packages: comfy-aimdo
  Attempting uninstall: comfy-aimdo
    Found existing installation: comfy-aimdo 0.2.9
    Uninstalling comfy-aimdo-0.2.9:
      Successfully uninstalled comfy-aimdo-0.2.9
Successfully installed comfy-aimdo-0.2.10.dev1
(venv) rattus@rattus-box2:~$ python ./foo.py 
aimdo: src/control.c:68:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce GTX 1660 SUPER (VRAM: 5746 MB)
using aimdo cudaMalloc @ 0x7f3363383fa0
using aimdo cudaFree   @ 0x7f3363384020
free=4877 MiB, test_size=3072 MiB
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=0, free_ms=16.203
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=1, free_ms=16.532
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=2, free_ms=17.337
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=3, free_ms=17.890
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=4, free_ms=17.183
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=5, free_ms=17.277
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=6, free_ms=17.316
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=7, free_ms=17.367
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=8, free_ms=17.327
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0x7f3280000000, size=3145728k, stream=(nil)
ok iter=9, free_ms=17.217
PASS
```

Windows:

before:

```
(venvw) PS C:\users\rattus> python .\foo.py
aimdo: src-win/cuda-detour.c:77:INFO:aimdo_setup_hooks: found driver at 00007FFDF1990000, installing 4 hooks
aimdo: src-win/cuda-detour.c:61:DEBUG:install_hook_entrys: hooks successfully installed
aimdo: src/control.c:69:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5060 (VRAM: 8150 MB)
using driver cuMemAlloc_v2 @ 0x7ffdf3f09e12
using driver cuMemFree_v2  @ 0x7ffdf3f09e30
free=7020 MiB, test_size=4352 MiB
aimdo: src/pyt-cu-plug-alloc.c:42:VERBOSE:alloc_fn (start): size=4456448k, device=0
aimdo: src/pyt-cu-plug-alloc.c:59:VERBOSE:alloc_fn (return): ptr=0000000204C00000
aimdo: src/pyt-cu-plug-alloc.c:78:DEBUG:Pytorch is freeing VRAM ...
aimdo: src/pyt-cu-plug-alloc.c:79:VERBOSE:free_fn (start) ptr=0000000204C00000 size=0k, device=0
aimdo: src/pyt-cu-plug-alloc.c:92:VERBOSE:Freed: ptr=0000000204C00000, size=0k, stream=0000000000000000
FAIL sync iter=0, free_ms=107.959: rc=700 (an illegal memory access was encountered)
aimdo: src-win/cuda-detour.c:99:DEBUG:aimdo_teardown_hooks: hooks successfully removed
```

after:

```
(venvw) PS C:\users\rattus> python .\foo.py
aimdo: src-win/cuda-detour.c:77:INFO:aimdo_setup_hooks: found driver at 00007FFDF1990000, installing 4 hooks
aimdo: src-win/cuda-detour.c:61:DEBUG:install_hook_entrys: hooks successfully installed
aimdo: src/control.c:69:INFO:comfy-aimdo inited for GPU: NVIDIA GeForce RTX 5060 (VRAM: 8150 MB)
using driver cuMemAlloc_v2 @ 0x7ffdf3f09e12
using driver cuMemFree_v2  @ 0x7ffdf3f09e30
free=7020 MiB, test_size=4352 MiB
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=0, free_ms=98.138
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=1, free_ms=98.444
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=2, free_ms=98.665
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=3, free_ms=94.875
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=4, free_ms=93.728
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=5, free_ms=94.744
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=6, free_ms=93.978
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=7, free_ms=94.496
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=8, free_ms=93.804
aimdo: src/pyt-cu-plug-alloc-async.c:72:VVERBOSE:Freed: ptr=0xb06800000, size=4456448k, stream=0000000000000000
ok iter=9, free_ms=95.184
PASS
aimdo: src-win/cuda-detour.c:99:DEBUG:aimdo_teardown_hooks: hooks successfully removed
```