### PR TITLE
[ROCm][Windows] revert reduced VRAM_CHUNK_SIZE

### DIFF
--- a/src-win/cuda-detour.c
+++ b/src-win/cuda-detour.c
@@ -21,7 +21,7 @@ static inline bool install_hook_entries(HookEntry *hooks, size_t num_hooks) {
 
     status = (int)DetourTransactionCommit();
     if (status != 0) {
-        log(ERROR, "%s: DetourTransactionCommit failed: %d", __func__, status);
+        log(ERROR, "%s: DetourTransactionCommit failed: %d\n", __func__, status);
         return false;
     }
 
@@ -55,7 +55,7 @@ void aimdo_teardown_hooks() {
 
     status = (int)DetourTransactionCommit();
     if (status != 0) {
-        log(ERROR, "%s: DetourDetach failed: %d", __func__, status);
+        log(ERROR, "%s: DetourDetach failed: %d\n", __func__, status);
     } else {
         log(DEBUG, "%s: hooks successfully removed\n", __func__);
     }

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -1,6 +1,6 @@
 #include "vrambuf.h"
 
-#if defined(__HIP_PLATFORM_AMD__)
+#if defined(__HIP_PLATFORM_AMD__) && !defined(_WIN32)
 #  define VRAM_CHUNK_SIZE      CUDA_PAGE_SIZE
 #else
 #  define VRAM_CHUNK_SIZE      (16ULL * 1024 * 1024)


### PR DESCRIPTION
### Contribution Agreement
- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).

###
On ROCm Windows, setting `VRAM_CHUNK_SIZE` to 16MB like CUDA works fine, and I've been using it this way for two months.