### PR TITLE
Fix ModelVBAR __del__ shutdown error (control is None)

### DIFF
--- a/comfy_aimdo/model_vbar.py
+++ b/comfy_aimdo/model_vbar.py
@@ -119,8 +119,10 @@ class ModelVBAR:
         return list(buf)
 
     def __del__(self):
-        if control.lib is not None and hasattr(self, '_ptr') and self._ptr:
-            lib.vbar_free(self._devctx, self._ptr)
+        ptr = getattr(self, "_ptr", None)
+        aimdo_lib = getattr(control, "lib", None)
+        if aimdo_lib is not None and ptr:
+            aimdo_lib.vbar_free(self._devctx, ptr)
             self._ptr = None
 
 def vbar_fault(alloc):


### PR DESCRIPTION
On interpreter shutdown, Python prints ignored exceptions from `ModelVBAR.__del__`:
```
Exception ignored in: <function ModelVBAR.__del__ at 0x000002C57F716160>
Traceback (most recent call last):
  File "c:\develop\venv\Lib\site-packages\comfy_aimdo\model_vbar.py", line 122, in __del__
AttributeError: 'NoneType' object has no attribute 'lib'
Exception ignored in: <function ModelVBAR.__del__ at 0x000002C57F716160>
Traceback (most recent call last):
  File "c:\develop\venv\Lib\site-packages\comfy_aimdo\model_vbar.py", line 122, in __del__
AttributeError: 'NoneType' object has no attribute 'lib'
```
Root cause

When Python exits, it clears module variables in an unpredictable order. The name control can already be `None` when `__del__` runs. The old check used `control.lib`, which raises the error above because you cannot read `.lib` on `None`.

Fix

- Get the library with `getattr(control, "lib", None)` and only call `vbar_free` if that value is not `None`.
- Get `self._ptr` with `getattr(self, "_ptr", None)` and only free if it is set.
- Call `vbar_free` on that validated library object so teardown does not depend on a possibly cleared module-level lib alias.