### PR TITLE
fix: use module attributes to detect vendor directly

### DIFF
--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -17,7 +17,6 @@ def detect_vendor():
             if ver_file.is_file():
                 spec = importlib.util.spec_from_file_location("torch_version_import", ver_file)
                 module = importlib.util.module_from_spec(spec)
-                importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
                 if module.cuda != None:
                     return "cuda"

--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -10,7 +10,6 @@ devctxs = []
 
 
 def detect_vendor():
-    version = ""
     try:
         torch_spec = importlib.util.find_spec("torch")
         for folder in torch_spec.submodule_search_locations:
@@ -18,16 +17,15 @@ def detect_vendor():
             if ver_file.is_file():
                 spec = importlib.util.spec_from_file_location("torch_version_import", ver_file)
                 module = importlib.util.module_from_spec(spec)
+                importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
-                version = module.__version__
+                if module.cuda != None:
+                    return "cuda"
+                if module.rocm != None:
+                    return "rocm"
     except Exception as e:
         logging.warning("Failed to detect Torch version")
         pass
-
-    if '+cu' in version:
-        return "cuda"
-    if '+rocm' in version:
-        return "rocm"
     return None
 
 


### PR DESCRIPTION
Current vendor check relies on `version.py`'s `__version__`:

https://github.com/Comfy-Org/comfy-aimdo/blob/604f3551d667c6cd34cd5f931d160b32e674ff66/comfy_aimdo/control.py#L12-L31

However, in my PC, `__version__` is `2.11.0` with no suffix, so this function returns `None`.

But..

```python
#/usr/lib/python3.14/site-packages/torch/version.py
from typing import Optional

__all__ = ['__version__', 'debug', 'cuda', 'git_version', 'hip', 'rocm', 'xpu']
__version__ = '2.11.0'
debug = False
cuda: Optional[str] = '13.2'
git_version = '70d99e998b4955e0049d13a98d77ae1b14db1f45'
hip: Optional[str] = None
rocm: Optional[str] = None
xpu: Optional[str] = None
```

I can use cuda actually.

So I refactor `detect_rendor` to use module attributes directly.

But I haven't tested if it break anything in other's PC. It works well on my PC. Could someone help me test it?


### Contribution Agreement

- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
