### PR TITLE
Handle Linux integrated GPU memory budgeting (CORE-128)

### DIFF
--- a/src-cuda/dispatch.c
+++ b/src-cuda/dispatch.c
@@ -28,6 +28,7 @@ static const DispatchSymbol dispatch_symbols[] = {
     { (void **)&g_cuda.p_cuCtxGetDevice, "cuCtxGetDevice", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
     { (void **)&g_cuda.p_cuCtxSynchronize, "cuCtxSynchronize", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
     { (void **)&g_cuda.p_cuDeviceGet, "cuDeviceGet", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
+    { (void **)&g_cuda.p_cuDeviceGetAttribute, "cuDeviceGetAttribute", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
     { (void **)&g_cuda.p_cuDeviceTotalMem, "cuDeviceTotalMem", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
     { (void **)&g_cuda.p_cuDeviceGetName, "cuDeviceGetName", CU_GET_PROC_ADDRESS_LEGACY_STREAM },
     { (void **)&g_cuda.p_cuMemGetInfo, "cuMemGetInfo", CU_GET_PROC_ADDRESS_LEGACY_STREAM },

--- a/src/control.c
+++ b/src/control.c
@@ -1,6 +1,54 @@
 #include "plat.h"
 #include "aimdo-time.h"
 
+#if !defined(_WIN32) && !defined(_WIN64) && !defined(__HIP_PLATFORM_AMD__)
+#define INTEGRATED_RAM_HEADROOM_MIN (2ULL * G)
+#define INTEGRATED_RAM_HEADROOM_MAX (8ULL * G)
+#define INTEGRATED_SIMPLE_ONLY_DEFICIT (-(ssize_t)(1ULL << 60))
+
+static size_t calculate_integrated_ram_headroom(size_t total_bytes) {
+    size_t headroom = total_bytes / 16;
+
+    if (headroom < INTEGRATED_RAM_HEADROOM_MIN) {
+        return INTEGRATED_RAM_HEADROOM_MIN;
+    }
+    if (headroom > INTEGRATED_RAM_HEADROOM_MAX) {
+        return INTEGRATED_RAM_HEADROOM_MAX;
+    }
+
+    return headroom;
+}
+
+static bool is_integrated_cuda_device(CUdevice dev) {
+    int integrated = 0;
+
+    return CHECK_CU(cuDeviceGetAttribute(&integrated, CU_DEVICE_ATTRIBUTE_INTEGRATED, dev)) &&
+           integrated;
+}
+
+static bool read_mem_available_bytes(size_t *mem_available_bytes) {
+    char line[256];
+    FILE *handle;
+
+    if (!mem_available_bytes || !(handle = fopen("/proc/meminfo", "r"))) {
+        return false;
+    }
+
+    while (fgets(line, sizeof(line), handle)) {
+        unsigned long long mem_available_kib;
+
+        if (sscanf(line, "MemAvailable: %llu kB", &mem_available_kib) == 1) {
+            fclose(handle);
+            *mem_available_bytes = (size_t)(mem_available_kib * K);
+            return true;
+        }
+    }
+
+    fclose(handle);
+    return false;
+}
+#endif
+
 _Thread_local AimdoContext *g_devctx;
 
 static AimdoContext *g_all_devctxs;
@@ -69,6 +117,27 @@ bool cuda_budget_deficit(const char **prevailing_deficit_method) {
     }
     control_timestamp_last_check = now;
     total_vram_last_check = total_vram_usage;
+
+#if !defined(_WIN32) && !defined(_WIN64) && !defined(__HIP_PLATFORM_AMD__)
+    if (integrated_device) {
+        size_t mem_available = 0;
+
+        if (!read_mem_available_bytes(&mem_available)) {
+            deficit_sync = INTEGRATED_SIMPLE_ONLY_DEFICIT;
+            return false;
+        }
+
+        deficit_sync = (ssize_t)integrated_ram_headroom - (ssize_t)mem_available;
+        *prevailing_deficit_method = "/proc/meminfo (integrated RAM)";
+        log(DEBUG,
+            "%s: MemAvailable poll available=%zu MB headroom=%zu MB deficit_sync=%zd MB recorded=%zu MB\n",
+            __func__, mem_available / M, integrated_ram_headroom / M,
+            deficit_sync / (ssize_t)M, total_vram_usage / M);
+        log(DEBUG, "%s: prevailing method %s\n", __func__, *prevailing_deficit_method);
+        return true;
+    }
+#endif
+
     if (!CHECK_CU(cuMemGetInfo(&free_vram, &total_vram))) {
         return false;
     }
@@ -143,6 +212,15 @@ bool init(const int *cuda_device_ids, size_t num_devices) {
             !aimdo_wddm_init(dev)) {
             goto fail;
         }
+
+#if !defined(_WIN32) && !defined(_WIN64) && !defined(__HIP_PLATFORM_AMD__)
+        devctx->_integrated_device = is_integrated_cuda_device(dev);
+        if (devctx->_integrated_device) {
+            devctx->_integrated_ram_headroom = calculate_integrated_ram_headroom(vram_capacity);
+            log(INFO, "comfy-aimdo integrated Linux GPU RAM headroom: %zu MB\n",
+                integrated_ram_headroom / M);
+        }
+#endif
 
         if (!CHECK_CU(cuDeviceGetName(dev_name, sizeof(dev_name), dev))) {
             sprintf(dev_name, "<unknown>");

--- a/src/control.h
+++ b/src/control.h
@@ -21,6 +21,7 @@ typedef struct AimdoContext {
     int _device_id;
 
     uint64_t _vram_capacity;
+    uint64_t _integrated_ram_headroom;
     uint64_t _total_vram_usage;
     uint64_t _total_vram_last_check;
     ssize_t _deficit_sync;
@@ -28,6 +29,7 @@ typedef struct AimdoContext {
     void *_highest_priority; /* ModelVBAR * */
     void *_lowest_priority; /* ModelVBAR * */
     bool _vbars_dirty;
+    bool _integrated_device;
     VramBuffer *_vmm_table[VMM_HASH_SIZE];
     SizeEntry *_size_table[SIZE_HASH_SIZE];
     void *_size_table_lock;
@@ -47,12 +49,14 @@ bool set_devctx_for_device(int device_id);
 bool set_devctx_for_current_cuda_device(void);
 
 #define vram_capacity               (g_devctx->_vram_capacity)
+#define integrated_ram_headroom     (g_devctx->_integrated_ram_headroom)
 #define total_vram_usage            (g_devctx->_total_vram_usage)
 #define total_vram_last_check       (g_devctx->_total_vram_last_check)
 #define deficit_sync                (g_devctx->_deficit_sync)
 #define highest_priority_p          (*(ModelVBAR **)&g_devctx->_highest_priority)
 #define lowest_priority_p           (*(ModelVBAR **)&g_devctx->_lowest_priority)
 #define vbars_dirty                 (g_devctx->_vbars_dirty)
+#define integrated_device           (g_devctx->_integrated_device)
 #define vmm_table                   (g_devctx->_vmm_table)
 #define size_table                  (g_devctx->_size_table)
 #define size_table_lock             (g_devctx->_size_table_lock)

--- a/src/gpu_abi.h
+++ b/src/gpu_abi.h
@@ -26,6 +26,10 @@ typedef struct CUctx_st *CUcontext;
 typedef struct CUstream_st *CUstream;
 typedef unsigned long long CUmemGenericAllocationHandle;
 
+typedef enum CUdevice_attribute_enum {
+    CU_DEVICE_ATTRIBUTE_INTEGRATED = 18,
+} CUdevice_attribute;
+
 typedef enum cudaError_enum {
     CUDA_SUCCESS = 0,
     CUDA_ERROR_OUT_OF_MEMORY = 2,

--- a/src/gpu_dispatch.h
+++ b/src/gpu_dispatch.h
@@ -12,6 +12,8 @@ typedef CUresult (CUDAAPI *PFN_cuGetErrorString)(CUresult error, const char **pS
 typedef CUresult (CUDAAPI *PFN_cuCtxGetDevice)(CUdevice *device);
 typedef CUresult (CUDAAPI *PFN_cuCtxSynchronize)(void);
 typedef CUresult (CUDAAPI *PFN_cuDeviceGet)(CUdevice *device, int ordinal);
+typedef CUresult (CUDAAPI *PFN_cuDeviceGetAttribute)(int *pi, CUdevice_attribute attrib,
+                                                     CUdevice dev);
 typedef CUresult (CUDAAPI *PFN_cuDeviceTotalMem)(size_t *bytes, CUdevice dev);
 typedef CUresult (CUDAAPI *PFN_cuDeviceGetName)(char *name, int len, CUdevice dev);
 typedef CUresult (CUDAAPI *PFN_cuMemGetInfo)(size_t *free_bytes, size_t *total_bytes);
@@ -46,6 +48,7 @@ typedef struct AimdoCudaDispatch {
     PFN_cuCtxGetDevice p_cuCtxGetDevice;
     PFN_cuCtxSynchronize p_cuCtxSynchronize;
     PFN_cuDeviceGet p_cuDeviceGet;
+    PFN_cuDeviceGetAttribute p_cuDeviceGetAttribute;
     PFN_cuDeviceTotalMem p_cuDeviceTotalMem;
     PFN_cuDeviceGetName p_cuDeviceGetName;
     PFN_cuMemGetInfo p_cuMemGetInfo;

--- a/src/plat.h
+++ b/src/plat.h
@@ -74,6 +74,7 @@ void *aimdo_find_loaded_module(const char *const *libraries, size_t library_coun
 #define cuCtxGetDevice              g_cuda.p_cuCtxGetDevice
 #define cuCtxSynchronize            g_cuda.p_cuCtxSynchronize
 #define cuDeviceGet                 g_cuda.p_cuDeviceGet
+#define cuDeviceGetAttribute        g_cuda.p_cuDeviceGetAttribute
 #define cuDeviceTotalMem            g_cuda.p_cuDeviceTotalMem
 #define cuDeviceGetName             g_cuda.p_cuDeviceGetName
 #define cuMemGetInfo                g_cuda.p_cuMemGetInfo


### PR DESCRIPTION
Detect integrated CUDA devices and reserve RAM headroom based on total shared memory. For Linux integrated GPUs, poll /proc/meminfo MemAvailable instead of cuMemGetInfo so eviction decisions respect system RAM pressure.

### Contribution Agreement
- [X] I agree that my contributions are licensed under the GPLv3.
- [X] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).

This adds proper support for GDX spark.
