### PR TITLE
hostbuf: dont trash reservation size on 0 truncate

### DIFF
--- a/src/hostbuf.c
+++ b/src/hostbuf.c
@@ -120,7 +120,6 @@ static bool hostbuf_truncate_impl(HostBuffer *hostbuf, uint64_t size, bool do_un
         hostbuf_release_address_space(hostbuf->base_address, (size_t)hostbuf->reserved_size);
         hostbuf->base_address = NULL;
         hostbuf->committed_size = 0;
-        hostbuf->reserved_size = 0;
     }
     log(VERBOSE, "%s: result hostbuf=%p size=%llu committed=%llu\n", __func__,
         (void *)hostbuf, (ull)hostbuf->size, (ull)hostbuf->committed_size);


### PR DESCRIPTION
This makes the hostbuf recoverable after a spurious truncate to 0.

### Contribution Agreement
- [X] I agree that my contributions are licensed under the GPLv3.
- [X] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
