### PR TITLE
hostbuf: Add ability to mark pages as cold after read

### DIFF
--- a/comfy_aimdo/host_buffer.py
+++ b/comfy_aimdo/host_buffer.py
@@ -17,7 +17,8 @@ if lib is not None:
     lib.hostbuf_get_raw_address.argtypes = [ctypes.c_void_p]
     lib.hostbuf_get_raw_address.restype = ctypes.c_void_p
 
-    lib.hostbuf_extend.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_bool, ctypes.POINTER(ctypes.c_int64)]
+    lib.hostbuf_extend.argtypes = [ctypes.c_void_p, ctypes.c_uint64, ctypes.c_bool,
+                                   ctypes.c_bool, ctypes.POINTER(ctypes.c_int64)]
     lib.hostbuf_extend.restype = ctypes.c_void_p
 
     lib.hostbuf_read_file_slice.argtypes = [
@@ -66,10 +67,11 @@ class HostBuffer:
         ptr = lib.hostbuf_get_raw_address(self._ptr)
         return int(ptr) if ptr else 0
 
-    def extend(self, size, reallocate=False):
+    def extend(self, size, reallocate=False, register=True):
         size = int(size)
         size_delta = ctypes.c_int64(0)
-        ptr = lib.hostbuf_extend(self._ptr, size, bool(reallocate), ctypes.byref(size_delta))
+        ptr = lib.hostbuf_extend(self._ptr, size, bool(reallocate), bool(register),
+                                 ctypes.byref(size_delta))
         self.size += size_delta.value
         if not ptr and size:
             raise RuntimeError("HostBuffer.extend failed")

--- a/comfy_aimdo/host_buffer.py
+++ b/comfy_aimdo/host_buffer.py
@@ -9,7 +9,7 @@ if os.name == "nt":
     import msvcrt
 
 if lib is not None:
-    lib.hostbuf_allocate.argtypes = [ctypes.c_uint64, ctypes.c_uint64]
+    lib.hostbuf_allocate.argtypes = [ctypes.c_uint64, ctypes.c_uint64, ctypes.c_bool]
     lib.hostbuf_allocate.restype = ctypes.c_void_p
 
     lib.hostbuf_free.argtypes = [ctypes.c_void_p]
@@ -51,12 +51,12 @@ def _file_handle(file_obj):
 
 
 class HostBuffer:
-    def __init__(self, size, prewarm=0, max_grow_size=0):
+    def __init__(self, size, prewarm=0, max_grow_size=0, mark_cold=True):
         size = int(size)
         max_mmap_size = max(size, int(max_grow_size))
         self.size = 0
         self.prewarm = max(0, int(prewarm))
-        self._ptr = lib.hostbuf_allocate(self.prewarm, max_mmap_size)
+        self._ptr = lib.hostbuf_allocate(self.prewarm, max_mmap_size, bool(mark_cold))
         if not self._ptr:
             raise RuntimeError("HostBuffer allocation failed")
         if size:

--- a/src-posix/xfer-file-plat.c
+++ b/src-posix/xfer-file-plat.c
@@ -1,10 +1,14 @@
+#define _GNU_SOURCE
+
 #include "plat.h"
 #include "xfer-file.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <unistd.h>
 
-bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination, size_t size) {
+bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination,
+                       size_t size, bool mark_cold) {
     int fd = (int)file_handle;
     size_t done = 0;
 
@@ -16,6 +20,14 @@ bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destin
             log(ERROR, "%s: pread failed at %llu (errno=%d)\n", __func__,
                 (ull)(offset + done), errno);
             return false;
+        }
+        if (mark_cold) {
+            int err = posix_fadvise(fd, (off_t)(offset + done), (off_t)n, POSIX_FADV_DONTNEED);
+
+            if (err) {
+                log_shot(WARNING, "%s: posix_fadvise failed at %llu size=%zd errno=%d\n",
+                         __func__, (ull)(offset + done), n, err);
+            }
         }
         done += (size_t)n;
     }

--- a/src-win/xfer-file-plat.c
+++ b/src-win/xfer-file-plat.c
@@ -3,10 +3,12 @@
 
 #include <windows.h>
 
-bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination, size_t size) {
+bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination,
+                       size_t size, bool mark_cold) {
     HANDLE handle = (HANDLE)(uintptr_t)file_handle;
     size_t done = 0;
 
+    (void)mark_cold;
     while (done < size) {
         DWORD got = 0;
         HANDLE event = CreateEventW(NULL, TRUE, FALSE, NULL);

--- a/src/hostbuf.c
+++ b/src/hostbuf.c
@@ -13,7 +13,7 @@ typedef struct HostBuffer {
     bool mark_cold;
 } HostBuffer;
 
-static bool hostbuf_grow(HostBuffer *hostbuf, uint64_t size) {
+static bool hostbuf_grow(HostBuffer *hostbuf, uint64_t size, bool do_register) {
     size_t page_size = hostbuf_page_size();
     uint64_t target_committed = ALIGN_UP(size + hostbuf->prewarm, page_size);
 
@@ -67,7 +67,8 @@ static bool hostbuf_grow(HostBuffer *hostbuf, uint64_t size) {
          !hostbuf_prewarm_join())) {
         goto fail_decommit;
     }
-    if (!CHECK_CU(cuMemHostRegister((char *)hostbuf->base_address + hostbuf->size,
+    if (do_register &&
+        !CHECK_CU(cuMemHostRegister((char *)hostbuf->base_address + hostbuf->size,
                                     (size_t)(size - hostbuf->size), 0))) {
         goto fail_decommit;
     }
@@ -85,7 +86,9 @@ static bool hostbuf_grow(HostBuffer *hostbuf, uint64_t size) {
     return true;
 
 fail_unregister:
-    CHECK_CU(cuMemHostUnregister((char *)hostbuf->base_address + hostbuf->size));
+    if (do_register) {
+        CHECK_CU(cuMemHostUnregister((char *)hostbuf->base_address + hostbuf->size));
+    }
 fail_decommit:
     if (tail_size) {
         hostbuf_decommit_address_space((char *)hostbuf->base_address + hostbuf->committed_size, tail_size);
@@ -170,7 +173,8 @@ void *hostbuf_get_raw_address(void *hostbuf_ptr) {
 }
 
 SHARED_EXPORT
-void *hostbuf_extend(void *hostbuf_ptr, uint64_t size, bool reallocate, int64_t *size_delta) {
+void *hostbuf_extend(void *hostbuf_ptr, uint64_t size, bool reallocate,
+                     bool do_register, int64_t *size_delta) {
     HostBuffer *hostbuf = (HostBuffer *)hostbuf_ptr;
     uint64_t old_size;
     uint64_t offset;
@@ -183,21 +187,22 @@ void *hostbuf_extend(void *hostbuf_ptr, uint64_t size, bool reallocate, int64_t 
 
     if (reallocate && hostbuf->last_chunk_size) {
         offset = hostbuf->size - hostbuf->last_chunk_size;
-        if (!CHECK_CU(cuMemHostUnregister((char *)hostbuf->base_address + offset))) {
+        if (do_register &&
+            !CHECK_CU(cuMemHostUnregister((char *)hostbuf->base_address + offset))) {
             return NULL;
         }
         hostbuf->size = offset;
     }
 
     offset = hostbuf->size;
-    if (!hostbuf_grow(hostbuf, offset + size)) {
+    if (!hostbuf_grow(hostbuf, offset + size, do_register)) {
         *size_delta = (int64_t)(hostbuf->size - old_size);
         return NULL;
     }
     hostbuf->last_chunk_size = hostbuf->size - offset;
     *size_delta = (int64_t)(hostbuf->size - old_size);
-    log(VERBOSE, "%s: hostbuf=%p request_size=%llu reallocate=%d offset=%llu ptr=%p size_delta=%lld result_size=%llu committed=%llu\n",
-        __func__, (void *)hostbuf, (ull)size, reallocate, (ull)offset,
+    log(VERBOSE, "%s: hostbuf=%p request_size=%llu reallocate=%d do_register=%d offset=%llu ptr=%p size_delta=%lld result_size=%llu committed=%llu\n",
+        __func__, (void *)hostbuf, (ull)size, reallocate, do_register, (ull)offset,
         (char *)hostbuf->base_address + offset, (long long)*size_delta,
         (ull)hostbuf->size, (ull)hostbuf->committed_size);
     return (char *)hostbuf->base_address + offset;

--- a/src/hostbuf.c
+++ b/src/hostbuf.c
@@ -10,6 +10,7 @@ typedef struct HostBuffer {
     uint64_t reserved_size;
     uint64_t last_chunk_size;
     uint64_t prewarm;
+    bool mark_cold;
 } HostBuffer;
 
 static bool hostbuf_grow(HostBuffer *hostbuf, uint64_t size) {
@@ -127,16 +128,17 @@ static bool hostbuf_truncate_impl(HostBuffer *hostbuf, uint64_t size, bool do_un
 }
 
 SHARED_EXPORT
-void *hostbuf_allocate(uint64_t prewarm, uint64_t reserved_size) {
+void *hostbuf_allocate(uint64_t prewarm, uint64_t reserved_size, bool mark_cold) {
     HostBuffer *hostbuf = calloc(1, sizeof(*hostbuf));
 
     if (!hostbuf) {
         return NULL;
     }
     hostbuf->prewarm = prewarm;
+    hostbuf->mark_cold = mark_cold;
     hostbuf->reserved_size = ALIGN_UP(reserved_size + prewarm, hostbuf_reserve_granularity());
-    log(VERBOSE, "%s: hostbuf=%p prewarm=%llu reserved_size=%llu\n",
-        __func__, (void *)hostbuf, (ull)prewarm, (ull)hostbuf->reserved_size);
+    log(VERBOSE, "%s: hostbuf=%p prewarm=%llu reserved_size=%llu mark_cold=%d\n",
+        __func__, (void *)hostbuf, (ull)prewarm, (ull)hostbuf->reserved_size, mark_cold);
     return hostbuf;
 }
 
@@ -213,17 +215,19 @@ bool hostbuf_read_file_slice(void *hostbuf_ptr, int device,
                              uint64_t file_handle, uint64_t file_offset,
                              uint64_t size, uint64_t offset,
                              cudaStream_t stream, uint64_t device_ptr) {
+    HostBuffer *hostbuf = (HostBuffer *)hostbuf_ptr;
     char *host;
 
-    host = (char *)hostbuf_get_raw_address(hostbuf_ptr) + offset;
     if (size == 0) {
         return true;
     }
-    if (!host) {
+    if (!hostbuf || !hostbuf->base_address) {
         return false;
     }
+    host = (char *)hostbuf->base_address + offset;
     if (!stream || !device_ptr) {
-        return xfer_file_read(file_handle, file_offset, host, (size_t)size);
+        return xfer_file_read(file_handle, file_offset, host, (size_t)size,
+                              hostbuf->mark_cold);
     }
     if (device < 0 || !set_devctx_for_device(device)) {
         return false;
@@ -231,7 +235,8 @@ bool hostbuf_read_file_slice(void *hostbuf_ptr, int device,
     for (uint64_t done = 0; done < size; done += HOSTBUF_STREAM_WINDOW) {
         size_t chunk = (size_t)MIN(HOSTBUF_STREAM_WINDOW, size - done);
 
-        if (!xfer_file_read(file_handle, file_offset + done, host + done, chunk) ||
+        if (!xfer_file_read(file_handle, file_offset + done, host + done, chunk,
+                            hostbuf->mark_cold) ||
             !CHECK_CU(cuMemcpyHtoDAsync((CUdeviceptr)(device_ptr + done), host + done,
                                         chunk, (CUstream)stream))) {
             return false;

--- a/src/xfer-file.c
+++ b/src/xfer-file.c
@@ -18,6 +18,7 @@ typedef struct {
     uint64_t offset;
     uint8_t *destination;
     size_t size;
+    bool mark_cold;
     XferFileWait *wait;
 } XferFileTask;
 
@@ -61,7 +62,8 @@ static THREAD_FUNC xfer_file_worker(void *arg) {
 
     (void)arg;
     while (xfer_file_task_pop(&g_xfer_file_reader, &task)) {
-        ok = xfer_file_read_at(task.file_handle, task.offset, task.destination, task.size);
+        ok = xfer_file_read_at(task.file_handle, task.offset, task.destination,
+                               task.size, task.mark_cold);
         mutex_lock(task.wait->mutex);
         task.wait->failed = !ok || task.wait->failed;
         if (--task.wait->pending == 0) {
@@ -72,7 +74,8 @@ static THREAD_FUNC xfer_file_worker(void *arg) {
     return 0;
 }
 
-bool xfer_file_read(XferFileHandle file_handle, uint64_t offset, void *destination, size_t size) {
+bool xfer_file_read(XferFileHandle file_handle, uint64_t offset, void *destination,
+                    size_t size, bool mark_cold) {
     XferFileWait wait = {
         .mutex = mutex_create(),
         .condvar = condvar_create(),
@@ -89,6 +92,7 @@ bool xfer_file_read(XferFileHandle file_handle, uint64_t offset, void *destinati
             .offset = offset + done,
             .destination = (uint8_t *)destination + done,
             .size = MIN(XFER_FILE_CHUNK_SIZE, size - done),
+            .mark_cold = mark_cold,
             .wait = &wait,
         };
 

--- a/src/xfer-file.h
+++ b/src/xfer-file.h
@@ -8,5 +8,7 @@ typedef uint64_t XferFileHandle;
 
 bool xfer_file_init(void);
 void xfer_file_cleanup(void);
-bool xfer_file_read(XferFileHandle file_handle, uint64_t offset, void *destination, size_t size);
-bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination, size_t size);
+bool xfer_file_read(XferFileHandle file_handle, uint64_t offset, void *destination,
+                    size_t size, bool mark_cold);
+bool xfer_file_read_at(XferFileHandle file_handle, uint64_t offset, void *destination,
+                       size_t size, bool mark_cold);


### PR DESCRIPTION
This is useful when reading to long-lived pins so that the linux disk cache can prioritize the rest instead for the next workflow run.

### Contribution Agreement
- [X] I agree that my contributions are licensed under the GPLv3.
- [X] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
