### PR TITLE
[ROCm] revert chunk size to 16MB

### DIFF
--- a/comfy_aimdo/vram_buffer.py
+++ b/comfy_aimdo/vram_buffer.py
@@ -4,12 +4,6 @@ from . import control
 
 lib = control.lib
 
-
-def _growth_chunk_size():
-    lib_name = str(getattr(lib, "_name", "")).lower()
-    return 2 * 1024**2 if "rocm" in lib_name else 16 * 1024**2
-
-
 if lib is not None:
     lib.vrambuf_create.argtypes = [ctypes.c_int, ctypes.c_size_t]
     lib.vrambuf_create.restype = ctypes.c_void_p
@@ -35,7 +29,7 @@ class VRAMBuffer:
 
         self.base_addr = lib.vrambuf_get(self._ptr)
         self._allocated = 0
-        self._chunk_size = _growth_chunk_size()
+        self._chunk_size = 16 * 1024**2
 
     def size(self):
         return self._allocated

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -1,10 +1,6 @@
 #include "vrambuf.h"
 
-#if defined(__HIP_PLATFORM_AMD__) && !defined(_WIN32)
-#  define VRAM_CHUNK_SIZE      CUDA_PAGE_SIZE
-#else
-#  define VRAM_CHUNK_SIZE      (16ULL * 1024 * 1024)
-#endif
+#define VRAM_CHUNK_SIZE (16ULL * M)
 
 SHARED_EXPORT
 void *vrambuf_create(int device, size_t max_size) {


### PR DESCRIPTION
Was intended to fix ROCm Windows' chunk size in `vram_buffer.py`, but it seems fine to revert Linux's as well, since we had this workaround to fix VMM bug:
https://github.com/Comfy-Org/comfy-aimdo/blob/7bbb4d4ac07aa27eb4aeef4fddd0410d82357870/src/plat.h#L14-L20

Wheel for testing: https://github.com/Comfy-Org/comfy-aimdo/actions/runs/26936503053

### Contribution Agreement
- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
