### PR TITLE
[ROCm][Windows] Recycle VRAMBuffer VA reservation to avoid HIP VMM crash

### DIFF
--- a/src/control.h
+++ b/src/control.h
@@ -45,6 +45,9 @@ typedef struct AimdoContext {
     void *_size_table_lock;
     HostbufFileReaderSlot _hostbuf_file_reader_slots[HOSTBUF_FILE_READER_SLOTS];
     int _hostbuf_file_reader_active;
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+    VramBuffer *_va_pool;
+#endif
 #if defined(_WIN32) || defined(_WIN64)
     void *_wddm_adapter; /* IDXGIAdapter3* */
     uint64_t _wddm_timestamp_last_check;
@@ -74,6 +77,9 @@ bool set_devctx_for_current_cuda_device(void);
 #define vmm_table                   (g_devctx->_vmm_table)
 #define size_table                  (g_devctx->_size_table)
 #define size_table_lock             (g_devctx->_size_table_lock)
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+#define va_pool                     (g_devctx->_va_pool)
+#endif
 #if defined(_WIN32) || defined(_WIN64)
 #define g_wddm_adapter              (*(IDXGIAdapter3 **)&g_devctx->_wddm_adapter)
 #define wddm_timestamp_last_check   (g_devctx->_wddm_timestamp_last_check)

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -1,9 +1,19 @@
 #include "vrambuf.h"
+#include "thread-plat.h"
 
 #if defined(__HIP_PLATFORM_AMD__) && !defined(_WIN32)
 #  define VRAM_CHUNK_SIZE      CUDA_PAGE_SIZE
 #else
 #  define VRAM_CHUNK_SIZE      (16ULL * 1024 * 1024)
+#endif
+
+/* ROCm/Windows mitigation: a HIP-runtime VMM defect faults after a large VA
+ * window is repeatedly reserved+freed per node. We keep the reservation alive
+ * and reuse it per (device, max_size); physical VRAM is still released on
+ * destroy, only the reserve/free pair is elided. */
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+static VramBuffer *g_va_pool;
+static Mutex g_va_pool_lock;
 #endif
 
 SHARED_EXPORT
@@ -15,6 +25,22 @@ void *vrambuf_create(int device, size_t max_size) {
     }
 
     max_size = CUDA_ALIGN_UP(max_size);
+
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+    if (!g_va_pool_lock) {
+        g_va_pool_lock = mutex_create();
+    }
+    mutex_lock(g_va_pool_lock);
+    for (VramBuffer **p = &g_va_pool; *p; p = &(*p)->next) {
+        if ((*p)->device == device && (*p)->max_size == max_size) {
+            buf = *p;
+            *p = buf->next;
+            mutex_unlock(g_va_pool_lock);
+            return (void *)buf;
+        }
+    }
+    mutex_unlock(g_va_pool_lock);
+#endif
 
     buf = (VramBuffer *)calloc(1, sizeof(*buf) + sizeof(CUmemGenericAllocationHandle) * max_size / VRAM_CHUNK_SIZE);
     if (!buf) {
@@ -112,8 +138,20 @@ bool vrambuf_destroy(void *arg) {
         CHECK_CU(cuMemRelease(buf->handles[i]));
     }
 
-    CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));
     total_vram_usage -= buf->allocated;
+
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+    /* VRAM freed; keep the VA reservation and park it for reuse. */
+    buf->allocated = 0;
+    buf->handle_count = 0;
+    mutex_lock(g_va_pool_lock);
+    buf->next = g_va_pool;
+    g_va_pool = buf;
+    mutex_unlock(g_va_pool_lock);
+    return true;
+#else
+    CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));
     free(buf);
     return true;
+#endif
 }

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -14,6 +14,26 @@
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
 static VramBuffer *g_va_pool;
 static Mutex g_va_pool_lock;
+static INIT_ONCE g_va_pool_lock_once = INIT_ONCE_STATIC_INIT;
+
+static BOOL CALLBACK init_va_pool_lock(PINIT_ONCE once, PVOID param, PVOID *ctx) {
+    (void)once;
+    (void)param;
+    g_va_pool_lock = mutex_create();
+    if (!g_va_pool_lock) {
+        return FALSE;
+    }
+    *ctx = (PVOID)g_va_pool_lock;
+    return TRUE;
+}
+
+static Mutex get_va_pool_lock(void) {
+    PVOID ctx = NULL;
+    if (!InitOnceExecuteOnce(&g_va_pool_lock_once, init_va_pool_lock, NULL, &ctx)) {
+        return NULL;
+    }
+    return (Mutex)ctx;
+}
 #endif
 
 SHARED_EXPORT
@@ -27,19 +47,20 @@ void *vrambuf_create(int device, size_t max_size) {
     max_size = CUDA_ALIGN_UP(max_size);
 
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
-    if (!g_va_pool_lock) {
-        g_va_pool_lock = mutex_create();
+    Mutex pool_lock = get_va_pool_lock();
+    if (!pool_lock) {
+        return NULL;
     }
-    mutex_lock(g_va_pool_lock);
+    mutex_lock(pool_lock);
     for (VramBuffer **p = &g_va_pool; *p; p = &(*p)->next) {
         if ((*p)->device == device && (*p)->max_size == max_size) {
             buf = *p;
             *p = buf->next;
-            mutex_unlock(g_va_pool_lock);
+            mutex_unlock(pool_lock);
             return (void *)buf;
         }
     }
-    mutex_unlock(g_va_pool_lock);
+    mutex_unlock(pool_lock);
 #endif
 
     buf = (VramBuffer *)calloc(1, sizeof(*buf) + sizeof(CUmemGenericAllocationHandle) * max_size / VRAM_CHUNK_SIZE);
@@ -144,10 +165,14 @@ bool vrambuf_destroy(void *arg) {
     /* VRAM freed; keep the VA reservation and park it for reuse. */
     buf->allocated = 0;
     buf->handle_count = 0;
-    mutex_lock(g_va_pool_lock);
+    Mutex pool_lock = get_va_pool_lock();
+    if (!pool_lock) {
+        return false;
+    }
+    mutex_lock(pool_lock);
     buf->next = g_va_pool;
     g_va_pool = buf;
-    mutex_unlock(g_va_pool_lock);
+    mutex_unlock(pool_lock);
     return true;
 #else
     CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -1,5 +1,4 @@
 #include "vrambuf.h"
-#include "thread-plat.h"
 
 #if defined(__HIP_PLATFORM_AMD__) && !defined(_WIN32)
 #  define VRAM_CHUNK_SIZE      CUDA_PAGE_SIZE
@@ -9,32 +8,8 @@
 
 /* ROCm/Windows mitigation: a HIP-runtime VMM defect faults after a large VA
  * window is repeatedly reserved+freed per node. We keep the reservation alive
- * and reuse it per (device, max_size); physical VRAM is still released on
- * destroy, only the reserve/free pair is elided. */
-#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
-static VramBuffer *g_va_pool;
-static Mutex g_va_pool_lock;
-static INIT_ONCE g_va_pool_lock_once = INIT_ONCE_STATIC_INIT;
-
-static BOOL CALLBACK init_va_pool_lock(PINIT_ONCE once, PVOID param, PVOID *ctx) {
-    (void)once;
-    (void)param;
-    g_va_pool_lock = mutex_create();
-    if (!g_va_pool_lock) {
-        return FALSE;
-    }
-    *ctx = (PVOID)g_va_pool_lock;
-    return TRUE;
-}
-
-static Mutex get_va_pool_lock(void) {
-    PVOID ctx = NULL;
-    if (!InitOnceExecuteOnce(&g_va_pool_lock_once, init_va_pool_lock, NULL, &ctx)) {
-        return NULL;
-    }
-    return (Mutex)ctx;
-}
-#endif
+ * and reuse it per max_size on the current device context; physical VRAM is
+ * still released on destroy, only the reserve/free pair is elided. */
 
 SHARED_EXPORT
 void *vrambuf_create(int device, size_t max_size) {
@@ -47,20 +22,14 @@ void *vrambuf_create(int device, size_t max_size) {
     max_size = CUDA_ALIGN_UP(max_size);
 
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
-    Mutex pool_lock = get_va_pool_lock();
-    if (!pool_lock) {
-        return NULL;
-    }
-    mutex_lock(pool_lock);
-    for (VramBuffer **p = &g_va_pool; *p; p = &(*p)->next) {
-        if ((*p)->device == device && (*p)->max_size == max_size) {
+    for (VramBuffer **p = &va_pool; *p; p = &(*p)->next) {
+        if ((*p)->max_size == max_size) {
             buf = *p;
             *p = buf->next;
-            mutex_unlock(pool_lock);
+            buf->next = NULL;
             return (void *)buf;
         }
     }
-    mutex_unlock(pool_lock);
 #endif
 
     buf = (VramBuffer *)calloc(1, sizeof(*buf) + sizeof(CUmemGenericAllocationHandle) * max_size / VRAM_CHUNK_SIZE);
@@ -165,14 +134,8 @@ bool vrambuf_destroy(void *arg) {
     /* VRAM freed; keep the VA reservation and park it for reuse. */
     buf->allocated = 0;
     buf->handle_count = 0;
-    Mutex pool_lock = get_va_pool_lock();
-    if (!pool_lock) {
-        return false;
-    }
-    mutex_lock(pool_lock);
-    buf->next = g_va_pool;
-    g_va_pool = buf;
-    mutex_unlock(pool_lock);
+    buf->next = va_pool;
+    va_pool = buf;
     return true;
 #else
     CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));


### PR DESCRIPTION
Recycle HIP VA reservations on ROCm/Windows instead of freeing them every node. Fixes `--enable-dynamic-vram` crashes (`0xE0` in `amdhip64_7.dll` on `hipMemAddressReserve` after couple of nodes).
Solution: `vrambuf_destroy` still unmaps/releases all physical VRAM, but parks the VA window in a pool keyed by (device, max_size). `vrambuf_create` reuses it instead of reserve/free each time. Linux and CUDA unchanged.