### PR TITLE
Make WDDM init non-fatal so aimdo works under Hyper-V GPU-PV

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -226,10 +226,13 @@ bool init(const int *cuda_device_ids, const uint64_t *extra_vram_headrooms, size
 
         if (!allocations_init() ||
             !CHECK_CU(cuDeviceGet(&dev, cuda_device_ids[i])) ||
-            !CHECK_CU(cuDeviceTotalMem(&vram_capacity, dev)) ||
-            !aimdo_wddm_init(dev)) {
+            !CHECK_CU(cuDeviceTotalMem(&vram_capacity, dev))) {
             goto fail;
         }
+        /* Non-fatal: WDDM/DXGI may be unavailable (e.g. Hyper-V GPU-PV).
+         * poll_budget_deficit falls back to cuMemGetInfo when g_wddm_adapter
+         * is NULL, which gives adequate budget tracking in that case. */
+        aimdo_wddm_init(dev);
 
 #if !defined(_WIN32) && !defined(_WIN64) && !defined(__HIP_PLATFORM_AMD__)
         devctx->_integrated_device = is_integrated_cuda_device(dev);


### PR DESCRIPTION
## Problem
On Windows running under Hyper-V with a paravirtualized GPU (GPU-PV), aimdo fails to initialize. `aimdo_wddm_init()` can't resolve a usable DXGI adapter (adapter enumeration / LUID match fails on the paravirtualized device), and because `init()` treated it as a hard requirement, the whole init aborted via `goto fail`.

## Fix
Treat `aimdo_wddm_init()` as best-effort. It already sets `g_wddm_adapter = NULL` on every failure path, and `poll_budget_deficit()`:
- guards the WDDM `QueryVideoMemoryInfo` call with `if (g_wddm_adapter)`, and
- always runs the `cuMemGetInfo` path regardless,

so with no WDDM adapter, budget tracking falls back to CUDA's `cuMemGetInfo`, which is adequate. No behavior change on systems where WDDM init succeeds.

## Testing
Confirmed aimdo now starts and runs on Windows under Hyper-V GPU-PV, where it previously failed at init.
System is a Windows 11 Pro Host/Guest with an RTX 5090.

### Contribution Agreement
- [X] I agree that my contributions are licensed under the GPLv3.
- [X] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
