### PR TITLE
docs: note AMD/ROCm support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This project is a pytorch VRAM allocator that implements on-demand offloading of
 
 ## Support:
 
-* **Nvidia GPUs only**
-* **Pytorch 2.8+**
-* **Cuda 12.8+**
+* **Nvidia GPUs** (CUDA) **and AMD GPUs** (ROCm/HIP)
+* **PyTorch 2.8+**
+* **CUDA 12.8+** (Nvidia) / **ROCm 7+** (AMD)
 * **Windows 11+** / **Linux** as per python ManyLinux support
 
 ---
@@ -48,6 +48,8 @@ see examples/example.py
 
 * VBAR allocation is done with `cuMemAddressReserve()`, faulting with `cuMemCreate()` and `cuMemMap()` and all frees done with appropriate converse APIs.
 * For consistency with VBAR memory management, main pytorch allocator plugin is also implemented with `cuMemAddressReserve` -> `cuMemCreate` -> `cuMemMap`. This also behaves a lot better on Windows systems with System Memory fallback.
+
+On AMD, the equivalent HIP APIs (`hipMemAddressReserve` -> `hipMemCreate` -> `hipMemMap`, and their converse calls) are used throughout via the same flow.
 
 ## Caveats:
 


### PR DESCRIPTION
## Summary

Updated docs to reflect existing AMD/ROCm support. The previous “Nvidia GPUs only” note was outdated; AMD support has been shipped via #35/#2.

Docs-only change, no functional impact.

### Contribution Agreement
- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).