### PR TITLE
Synchronize CUDA before VBAR fault eviction

### DIFF
--- a/src/model-vbar.c
+++ b/src/model-vbar.c
@@ -344,6 +344,13 @@ int vbar_fault(void *devctx, void *vbar, uint64_t offset, uint64_t size, uint32_
 
     set_devctx((AimdoContext *)devctx);
 
+    /*
+     * vbar_fault can evict and unmap pages while CUDA work from the previous
+     * layer is still consuming them. Complete in-flight work before any
+     * residency changes to avoid use-after-unmap and driver TDR failures.
+     */
+    CHECK_CU(cuCtxSynchronize());
+
     size_t page_end = VBAR_GET_PAGE_NR_UP(offset + size);
 
     log(VVERBOSE, "%s (start): offset=%lldk, size=%lldk\n", __func__, (ull)(offset / K), (ull)(size / K));


### PR DESCRIPTION
## What changed

Add a CUDA context synchronization boundary at the start of `vbar_fault()`, after selecting the AIMDO device context and before any budget-driven residency changes can occur.

## Root cause

`vbar_fault()` can run while a kernel launched for the preceding layer is still consuming VBAR-backed pages. Its budget enforcement path may then evict and unmap those pages. That creates a use-after-unmap race in the CUDA virtual-memory layer, which can manifest as nondeterministic inference corruption, a stuck first sampler step, or a Windows `nvlddmkm` TDR/reset rather than a recoverable Python exception.

This is the remaining unsynchronized residency boundary described in #65; the other major unmap paths already synchronize around their changes.

## Impact

The synchronization trades some asynchronous overlap at model page-fault boundaries for deterministic page-lifetime safety. It does not alter exported APIs, page accounting, or wheel compatibility.

## Validation

- Branch is based on the exact `v0.4.10` release commit (`ace72ab`).
- Diff is limited to seven added lines in `src/model-vbar.c`.
- GitHub Actions validation is pending on this draft PR.

Addresses #65.