### PR TITLE
bugfix: Detect the vendor from torch's hip/cuda build variables

### DIFF
--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -28,6 +28,8 @@ def _native_log(level, message):
 
 def detect_vendor():
     version = ""
+    hip = None
+    cuda = None
     try:
         torch_spec = importlib.util.find_spec("torch")
         for folder in torch_spec.submodule_search_locations:
@@ -37,9 +39,20 @@ def detect_vendor():
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
                 version = module.__version__
+                hip = getattr(module, "hip", None)
+                cuda = getattr(module, "cuda", None)
     except Exception as e:
         logging.warning("Failed to detect Torch version")
         pass
+
+    # The local version suffix is only present on the official wheels; a torch
+    # built from source reports a plain "2.12.0". version.py always sets hip and
+    # cuda for the build it came from, so prefer those and keep the suffix
+    # sniffing as a fallback.
+    if hip:
+        return "rocm"
+    if cuda:
+        return "cuda"
 
     if '+cu' in version:
         return "cuda"


### PR DESCRIPTION
Checking for +rocm or +cu is not a stable way to detect which vendor build is in use. That suffix is only applied for official builds and if you just do a naive source build or have a slightly bespoke build system that builds from source, it will not contain that suffix. (Specifically building from nix and it does not contain it)

Having a local build of torch which does not have the suffix leads to not detecting rocm correctly, and so enabling --enable-dynamic-vram just errors out and falls back since it tries to use the wrong .so for nvidia which obviously fails to load. `aimdo_find_loaded_module: failed to find an already-loaded module`

torch/version.py already defines hip and cuda for the build it came from, and detect_vendor() is executing that exact file, so read them there.

Checked against a source-built ROCm torch and that the dynamic vram does work with my nix build version of comfyui and ROCM torch