### PR TITLE
Improve alignment between the ROCm and CUDA backends

### DIFF
--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -28,6 +28,8 @@ def _native_log(level, message):
 
 def detect_vendor():
     version = ""
+    hip = None
+    cuda = None
     try:
         torch_spec = importlib.util.find_spec("torch")
         for folder in torch_spec.submodule_search_locations:
@@ -37,9 +39,18 @@ def detect_vendor():
                 module = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(module)
                 version = module.__version__
+                hip = getattr(module, "hip", None)
+                cuda = getattr(module, "cuda", None)
     except Exception as e:
         logging.warning("Failed to detect Torch version")
         pass
+
+    # torch.version.hip/cuda are authoritative. The local version segment is only
+    # a fallback: ROCm nightlies do not always carry a +rocm suffix.
+    if hip:
+        return "rocm"
+    if cuda:
+        return "cuda"
 
     if '+cu' in version:
         return "cuda"

--- a/src-hip/dispatch.c
+++ b/src-hip/dispatch.c
@@ -31,9 +31,14 @@ static CUresult CUDAAPI aimdo_hip_mem_alloc_host(void **pp, size_t bytesize) {
 static const DispatchSymbol dispatch_symbols[] = {
     { (void **)&g_cuda.p_cuInit, "hipInit" },
     { (void **)&g_cuda.p_cuGetErrorString, "hipDrvGetErrorString" },
+    /* hipGetDevice cannot report the absent-context failure cuCtxGetDevice uses,
+     * but HIP binds an unbound thread to device 0 and allocates there, so
+     * following the current device stays correct.
+     */
     { (void **)&g_cuda.p_cuCtxGetDevice, "hipGetDevice" },
     { (void **)&g_cuda.p_cuCtxSynchronize, "hipDeviceSynchronize" },
     { (void **)&g_cuda.p_cuDeviceGet, "hipDeviceGet" },
+    { (void **)&g_cuda.p_cuDeviceGetAttribute, "hipDeviceGetAttribute" },
     { (void **)&g_cuda.p_cuDeviceTotalMem, "hipDeviceTotalMem" },
     { (void **)&g_cuda.p_cuDeviceGetName, "hipDeviceGetName" },
     { (void **)&g_cuda.p_cuMemGetInfo, "hipMemGetInfo" },
@@ -61,8 +66,8 @@ static const DispatchSymbol dispatch_symbols[] = {
 
 static const char *const hip_library_names[] = {
 #if defined(_WIN32) || defined(_WIN64)
-    "amdhip64.dll",
     "amdhip64_7.dll",
+    "amdhip64.dll",
 #else
     "libamdhip64.so.7",
     "libamdhip64.so.6",
@@ -106,9 +111,15 @@ bool aimdo_cuda_runtime_init(void) {
     g_cuda.p_cuMemAllocAsync_ptsz = g_cuda.p_cuMemAllocAsync;
     g_cuda.p_cuMemFreeAsync_ptsz = g_cuda.p_cuMemFreeAsync;
 
-    g_device_get_properties = (PFN_deviceGetProperties)aimdo_hip_resolve_symbol("hipGetDevicePropertiesR0600");
+    /* Only the R0600 revision is usable: callers read the uuid and luid fields,
+     * which the R0000 struct does not have. The unversioned hipGetDeviceProperties
+     * export still resolves on current runtimes but carries the R0000 layout, so
+     * falling back to it would hand back an unrelated LUID.
+     */
+    g_device_get_properties =
+        (PFN_deviceGetProperties)aimdo_hip_resolve_symbol("hipGetDevicePropertiesR0600");
     if (!g_device_get_properties) {
-        g_device_get_properties = (PFN_deviceGetProperties)aimdo_hip_resolve_symbol("hipGetDeviceProperties");
+        log(WARNING, "%s: hipGetDevicePropertiesR0600 unavailable\n", __func__);
     }
 
     {

--- a/src-win/shmem-detect.c
+++ b/src-win/shmem-detect.c
@@ -91,7 +91,7 @@ fail:
     if (factory) {
         factory->lpVtbl->Release(factory);
     }
-    log(WARNING, "comfy-aimdo WDDM init failed (%d). aimdo is blind to the CUDA Sysmem Fallback Policy\n", fail_code);
+    log(WARNING, "comfy-aimdo WDDM init failed (%d). aimdo is blind to the driver sysmem fallback policy\n", fail_code);
     return false;
 }
 

--- a/src/control.c
+++ b/src/control.c
@@ -2,7 +2,7 @@
 #include "aimdo-time.h"
 #include "xfer-file.h"
 
-#if !defined(_WIN32) && !defined(_WIN64) && defined(AIMDO_CUDA)
+#if !defined(_WIN32) && !defined(_WIN64)
 #define INTEGRATED_RAM_HEADROOM_MIN (2ULL * G)
 #define INTEGRATED_RAM_HEADROOM_MAX (8ULL * G)
 #define INTEGRATED_SIMPLE_ONLY_DEFICIT (-(ssize_t)(1ULL << 60))
@@ -140,7 +140,7 @@ bool cuda_budget_deficit(const char **prevailing_deficit_method) {
     control_timestamp_last_check = now;
     total_vram_last_check = total_vram_usage;
 
-#if !defined(_WIN32) && !defined(_WIN64) && defined(AIMDO_CUDA)
+#if !defined(_WIN32) && !defined(_WIN64)
     if (integrated_device) {
         size_t mem_available = 0;
 
@@ -249,7 +249,7 @@ bool init(const int *cuda_device_ids, const uint64_t *extra_vram_headrooms, size
             goto fail;
         }
 
-#if !defined(_WIN32) && !defined(_WIN64) && defined(AIMDO_CUDA)
+#if !defined(_WIN32) && !defined(_WIN64)
         devctx->_integrated_device = is_integrated_cuda_device(dev);
         if (devctx->_integrated_device) {
             devctx->_integrated_ram_headroom = calculate_integrated_ram_headroom(vram_capacity);

--- a/src/control.c
+++ b/src/control.c
@@ -209,6 +209,7 @@ void cleanup(void) {
         set_devctx(&g_all_devctxs[i]);
         hostbuf_file_reader_cleanup();
         aimdo_wddm_cleanup();
+        va_pool_cleanup();
         allocations_cleanup();
 
         free(highest_priority_p); /* FIXME: move the model_vbar. */
@@ -242,6 +243,7 @@ bool init(const int *cuda_device_ids, const uint64_t *extra_vram_headrooms, size
         set_devctx(devctx);
 
         if (!allocations_init() ||
+            !va_pool_init() ||
             !CHECK_CU(cuDeviceGet(&dev, cuda_device_ids[i])) ||
             !CHECK_CU(cuDeviceTotalMem(&vram_capacity, dev))) {
             goto fail;

--- a/src/control.h
+++ b/src/control.h
@@ -51,6 +51,7 @@ typedef struct AimdoContext {
     int _hostbuf_file_reader_active;
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
     VramBuffer *_va_pool;
+    void *_va_pool_lock;
 #endif
 #if defined(_WIN32) || defined(_WIN64)
     void *_wddm_adapter; /* IDXGIAdapter3* */
@@ -87,6 +88,7 @@ bool set_devctx_for_current_cuda_device(void);
 #define size_table_lock             (g_devctx->_size_table_lock)
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
 #define va_pool                     (g_devctx->_va_pool)
+#define va_pool_lock                (g_devctx->_va_pool_lock)
 #endif
 #if defined(_WIN32) || defined(_WIN64)
 #define g_wddm_adapter              (*(IDXGIAdapter3 **)&g_devctx->_wddm_adapter)

--- a/src/gpu_abi.h
+++ b/src/gpu_abi.h
@@ -31,8 +31,16 @@ typedef struct CUuuid_st {
     char bytes[16];
 } CUuuid;
 
+/* hipDeviceAttribute_t is not numerically compatible with CUdevice_attribute.
+ * hipDeviceAttributeIntegrated is 16, so querying a HIP device with the CUDA
+ * value would read hipDeviceAttributeKernelExecTimeout instead.
+ */
 typedef enum CUdevice_attribute_enum {
+#if defined(__HIP_PLATFORM_AMD__)
+    CU_DEVICE_ATTRIBUTE_INTEGRATED = 16,
+#else
     CU_DEVICE_ATTRIBUTE_INTEGRATED = 18,
+#endif
 } CUdevice_attribute;
 
 typedef enum cudaError_enum {

--- a/src/plat.h
+++ b/src/plat.h
@@ -221,6 +221,15 @@ fail:
     return err;
 }
 
+/* vrambuf.c */
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+bool va_pool_init(void);
+void va_pool_cleanup(void);
+#else
+static inline bool va_pool_init(void) { return true; }
+static inline void va_pool_cleanup(void) {}
+#endif
+
 /* model_vbar.c */
 size_t vbars_free(ssize_t size);
 SHARED_EXPORT

--- a/src/vrambuf.c
+++ b/src/vrambuf.c
@@ -1,4 +1,5 @@
 #include "vrambuf.h"
+#include "thread-plat.h"
 
 #if defined(__HIP_PLATFORM_AMD__) && !defined(_WIN32)
 #  define VRAM_CHUNK_SIZE      CUDA_PAGE_SIZE
@@ -11,6 +12,38 @@
  * and reuse it per max_size on the current device context; physical VRAM is
  * still released on destroy, only the reserve/free pair is elided. */
 
+#if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+/* The pool hangs off AimdoContext, which is shared by every thread bound to the
+ * device, and vrambuf_destroy runs on whichever thread drops the last python
+ * reference. The list therefore needs the same treatment as the size table.
+ */
+bool va_pool_init(void) {
+    return (va_pool_lock = (void *)mutex_create()) != NULL;
+}
+
+void va_pool_cleanup(void) {
+    VramBuffer *buf;
+
+    if (!va_pool_lock) {
+        return;
+    }
+
+    mutex_lock((Mutex)va_pool_lock);
+    for (buf = va_pool; buf; ) {
+        VramBuffer *next = buf->next;
+
+        CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));
+        free(buf);
+        buf = next;
+    }
+    va_pool = NULL;
+    mutex_unlock((Mutex)va_pool_lock);
+
+    mutex_destroy((Mutex)va_pool_lock);
+    va_pool_lock = NULL;
+}
+#endif
+
 SHARED_EXPORT
 void *vrambuf_create(int device, size_t max_size) {
     VramBuffer *buf;
@@ -22,14 +55,17 @@ void *vrambuf_create(int device, size_t max_size) {
     max_size = CUDA_ALIGN_UP(max_size);
 
 #if defined(__HIP_PLATFORM_AMD__) && defined(_WIN32)
+    mutex_lock((Mutex)va_pool_lock);
     for (VramBuffer **p = &va_pool; *p; p = &(*p)->next) {
         if ((*p)->max_size == max_size) {
             buf = *p;
             *p = buf->next;
             buf->next = NULL;
+            mutex_unlock((Mutex)va_pool_lock);
             return (void *)buf;
         }
     }
+    mutex_unlock((Mutex)va_pool_lock);
 #endif
 
     buf = (VramBuffer *)calloc(1, sizeof(*buf) + sizeof(CUmemGenericAllocationHandle) * max_size / VRAM_CHUNK_SIZE);
@@ -134,8 +170,10 @@ bool vrambuf_destroy(void *arg) {
     /* VRAM freed; keep the VA reservation and park it for reuse. */
     buf->allocated = 0;
     buf->handle_count = 0;
+    mutex_lock((Mutex)va_pool_lock);
     buf->next = va_pool;
     va_pool = buf;
+    mutex_unlock((Mutex)va_pool_lock);
     return true;
 #else
     CHECK_CU(cuMemAddressFree(buf->base_ptr, buf->max_size));


### PR DESCRIPTION
Five places where the HIP backend has drifted from the CUDA one, found by diffing the two side by side. Some are plainly bugs, some are divergences, marked below.

- **Integrated GPU budgeting was CUDA only.** https://github.com/Comfy-Org/comfy-aimdo/commit/159abbe landed behind a `!defined(__HIP_PLATFORM_AMD__)` guard, so APUs on ROCm get budgeted against `hipMemGetInfo` rather than `/proc/meminfo` `MemAvailable`. Enabling it needs a per-backend attribute value: `hipDeviceAttributeIntegrated` is 16, so reusing the CUDA 18 would have queried `hipDeviceAttributeKernelExecTimeout`. *Whether the `MemAvailable` heuristic suits an AMD APU needs testing.*
- **The `hipGetDeviceProperties` fallback returns the wrong struct layout.** `shmem-detect.c` reads `uuid` and `luid`, which the R0000 layout does not have, so the fallback can only ever produce a bogus LUID and a failed adapter match. Removed rather than fixed. *Latent; the R0600 lookup succeeds on current runtimes.*
- **The ROCm/Windows VA pool was unsynchronised and leaked.** https://github.com/Comfy-Org/comfy-aimdo/commit/2362071 added a mutex, https://github.com/Comfy-Org/comfy-aimdo/commit/c760f6a moved the pool into `AimdoContext` and dropped it, but that struct is shared across threads and `vrambuf_destroy` runs on whichever thread drops the last Python reference. Nothing drained the pool either, so parked reservations leaked across `init`/`cleanup` cycles. *Leak is a straightforward bug; race is real by inspection, not reproduced.*
- **Vendor detection missed ROCm nightlies.** `torch.version.hip` is authoritative and is checked before the `+rocm` string match. *Defensive; current wheels do carry `+rocm`.*
- **The Windows runtime lookup checked the legacy name first.** `amdhip64_7.dll` is now searched before the unsuffixed ROCm 5 era `amdhip64.dll`. *Cosmetic ordering change.*

## Testing

Linux and APUs are the gap: Windows on a discrete RDNA4 card (gfx1200) is already covered, see below.

Nothing needs building. CI builds wheels for every push to this PR. On the Checks tab open the latest Build Wheels run, download the artifact for your platform (`wheels-windows-amd64`, `wheels-linux-x86_64`, and so on), and unzip it to get a `.whl`. Then, with ComfyUI closed, install it into ComfyUI's venv:

```
# Windows
pip install --force-reinstall --no-deps comfy_aimdo-0.4.14.dev9-cp39-abi3-win_amd64.whl

# Linux, where the manylinux tag list makes the name long
pip install --force-reinstall --no-deps comfy_aimdo-0.4.14.dev9-cp39-abi3-manylinux*.whl
```

The version in the file name moves with each push, so use whatever the artifact you downloaded actually contains. Downloading run artifacts requires being signed in to GitHub. To go back afterwards: `pip install --force-reinstall --no-deps comfy-aimdo==<the version you had>`.

If you would rather build it yourself, `.github/workflows/build-wheels.yml` carries the exact commands for both platforms.

## Verification

CI is green on all four wheel targets, linux x86_64 and aarch64 and windows amd64 and arm64, which builds both backends on both platforms. `hipDeviceAttributeIntegrated == 16` was confirmed against the ROCm headers and by querying a live gfx1200 GPU.

Run in ComfyUI on Windows on a discrete gfx1200 (RDNA4) card with a current ROCm PyTorch wheel, on workloads that offload: behaves the same as upstream. That exercises runtime and symbol resolution, the WDDM adapter match through the R0600 lookup, and the hook dedup.

It does not exercise the integrated path, which is compiled out on Windows. No Linux ROCm install or APU was available here, so that one is compiled but never run and is where testing would help most.