### PR TITLE
Set Windows NVML pressure headroom to 768 MB

### DIFF
--- a/src-win/shmem-detect.c
+++ b/src-win/shmem-detect.c
@@ -104,6 +104,7 @@ fail:
 /* FIXME: This should be 0 if sysmem fallback is disabled by the user */
 #define WDDM_BUDGET_HEADROOM (512 * 1024 * 1024)
 #define CUDA_BUDGET_HEADROOM (192 * 1024 * 1024)
+#define NVML_BUDGET_HEADROOM (768 * 1024 * 1024)
 
 bool poll_budget_deficit(const char **prevailing_deficit_method)
 {
@@ -140,7 +141,8 @@ bool poll_budget_deficit(const char **prevailing_deficit_method)
     used_nvml = nvml_device && aimdo_nvml_memory_info(nvml_device, &free_vram, &total_vram);
 #endif
     if (used_nvml || CHECK_CU(cuMemGetInfo(&free_vram, &total_vram))) {
-        ssize_t deficit_cuda = (ssize_t)(CUDA_BUDGET_HEADROOM / 2) - (ssize_t)free_vram;
+        ssize_t headroom = used_nvml ? NVML_BUDGET_HEADROOM : CUDA_BUDGET_HEADROOM / 2;
+        ssize_t deficit_cuda = headroom - (ssize_t)free_vram;
 
         log(DEBUG,
             "%s: device memory free=%zu MB total=%zu MB deficit_cuda=%zd MB\n",


### PR DESCRIPTION
This avoids deadlocked sysmem fallback in some conditions. Some systems get stuck with NVML as the only pressure release mechanism and the cuda based headroom is too small.