### PR TITLE
Set Windows NVML pressure headroom to 512 MB

### DIFF
--- a/src-win/shmem-detect.c
+++ b/src-win/shmem-detect.c
@@ -104,7 +104,7 @@ fail:
 /* FIXME: This should be 0 if sysmem fallback is disabled by the user */
 #define WDDM_BUDGET_HEADROOM (512 * 1024 * 1024)
 #define CUDA_BUDGET_HEADROOM (192 * 1024 * 1024)
-#define NVML_BUDGET_HEADROOM (768 * 1024 * 1024)
+#define NVML_BUDGET_HEADROOM (512 * 1024 * 1024)
 
 bool poll_budget_deficit(const char **prevailing_deficit_method)
 {


### PR DESCRIPTION
Amp-Thread-ID: https://ampcode.com/threads/T-01a02c89-71c2-735f-b55b-84f8b2e8da3d

@jtydhr88 test confirms this is the best compromise the NVML under-pressure bug.