### PR TITLE
Refuse a second init_devices() before plat_init()

### DIFF
--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -146,6 +146,10 @@ def init_devices(device_ids):
     if lib is None:
         return False
 
+    if devctxs:
+        logging.warning("comfy-aimdo devices are already initialized, call deinit() first")
+        return False
+
     requested = []
     headrooms = []
     for device_id in device_ids:

--- a/tests/init-devices-twice-cuda.py
+++ b/tests/init-devices-twice-cuda.py
@@ -1,0 +1,19 @@
+# A second init_devices() must be refused, not reinstall the CUDA hooks over
+# the live ones and crash the next allocation.
+import comfy_aimdo.control as aimdo
+import torch
+
+
+assert aimdo.init("cuda")
+device = torch.cuda.current_device()
+assert aimdo.init_device(device)
+assert not aimdo.init_device(device)
+
+x = torch.empty(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+x.fill_(1)
+torch.cuda.synchronize()
+assert x[-1].item() == 1
+assert aimdo.get_total_vram_usage() > 0
+del x
+aimdo.deinit()
+print("init_devices twice test passed")


### PR DESCRIPTION
Calling `init_devices()` twice crashes the process on the next allocation.

The second call runs `plat_init()` again. That installs a new set of CUDA hooks over the live ones, so the first set is orphaned. `lib.init()` then rejects the duplicate devices, and the failure path calls `plat_cleanup()`, which tears down the live hooks and zeroes the dispatch table. The next torch allocation lands in the orphaned hook and calls `cuCtxGetDevice` through a NULL slot (`src/control.c:102`). Python saw `init_devices()` return False and then died.

Refuse the call while `devctxs` is non-empty. `deinit()` first is the supported way to reinitialize, as before. Python only; `plat_init()` itself stays non-reentrant (`aimdo_setup_hooks` stacks a second hook set, `xfer_file_init` resets a live thread pool), which is a separate C change I can send next.

Found while probing from [comfy-env](https://github.com/PozzettiAndrea/comfy-env), which initializes aimdo per worker subprocess ([memory_manager.py:261-268](https://github.com/PozzettiAndrea/comfy-env/blob/7f61cc62f1ea62cd4ab7169a38bf055556eedf2c/src/comfy_env/memory_manager.py#L261-L268)). `tests/init-devices-twice-cuda.py`: exit 139 on 0.4.13, passes with this patch. RTX 3090, torch 2.8 cu128.

### Contribution Agreement
- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
