### PR TITLE
Add runtime simple_vram_headroom accessors

### DIFF
--- a/comfy_aimdo/control.py
+++ b/comfy_aimdo/control.py
@@ -101,6 +101,9 @@ def init(implementation: str | None = None, simple_vram_headroom: int | None = N
     lib.set_simple_vram_headroom.argtypes = [ctypes.c_int64]
     lib.set_simple_vram_headroom.restype = None
 
+    lib.get_simple_vram_headroom.argtypes = []
+    lib.get_simple_vram_headroom.restype = ctypes.c_int64
+
     lib.set_nvml_pressure.argtypes = [ctypes.c_bool]
     lib.set_nvml_pressure.restype = None
 
@@ -193,6 +196,33 @@ def get_devctx(device_id: int):
     if devctx:
         return devctx
     raise RuntimeError(f"comfy-aimdo device {device_id} is not initialized")
+
+def set_simple_vram_headroom(headroom: int):
+    """Set the VRAM the simple budget keeps free, in bytes.
+
+    One process wide value, compared against each device's own capacity. It
+    is separate from the per device extra_vram_headroom given to
+    init_devices(). Only the simple budget term reads it; the measured poll
+    term keeps its own compile time floor of 256 MB (VRAM_HEADROOM) and the
+    budget takes the larger of the two, so raising this above 256 MB is
+    honoured but lowering it below 256 MB changes nothing. Raising it takes
+    effect at the next VBAR fault or hooked device allocation and is honoured
+    by evicting VBAR pages only; torch allocations are counted against it
+    but never refused. Lowering it does not refill anything by itself: pages
+    come back when a VBAR is next prioritized, which ComfyUI does when it
+    loads a model.
+    """
+    headroom = int(headroom)
+    if headroom < 0 or headroom > (1 << 60):
+        raise ValueError("simple_vram_headroom must be between 0 and 2**60 bytes")
+    if lib is None:
+        raise RuntimeError("comfy-aimdo is not initialized")
+    lib.set_simple_vram_headroom(headroom)
+
+def get_simple_vram_headroom():
+    if lib is None:
+        raise RuntimeError("comfy-aimdo is not initialized")
+    return int(lib.get_simple_vram_headroom())
 
 def deinit():
     global lib, devctxs, _log_callback

--- a/src/control.c
+++ b/src/control.c
@@ -65,6 +65,11 @@ void set_simple_vram_headroom(int64_t bytes) {
 }
 
 SHARED_EXPORT
+int64_t get_simple_vram_headroom(void) {
+    return simple_vram_headroom;
+}
+
+SHARED_EXPORT
 void set_nvml_pressure(bool enabled) {
     nvml_pressure = enabled;
 }

--- a/tests/simple-vram-headroom-runtime-cuda.py
+++ b/tests/simple-vram-headroom-runtime-cuda.py
@@ -1,0 +1,81 @@
+# A simple_vram_headroom set after init_devices() steers the next VBAR fault.
+# The model is a quarter of VRAM; the runtime headroom leaves room for half.
+import gc
+import os
+
+os.environ.setdefault("PYTORCH_ALLOC_CONF", "backend:cudaMallocAsync")
+
+import comfy_aimdo.control as aimdo
+import torch
+
+
+M = 1024 * 1024
+PAGE = 32 * M
+CHUNK = 128 * M
+DEFAULT_HEADROOM = 256 * M
+
+assert aimdo.init("cuda")
+import comfy_aimdo.torch  # noqa: E402
+from comfy_aimdo.model_vbar import ModelVBAR, vbar_fault, vbar_unpin  # noqa: E402
+
+device = torch.cuda.current_device()
+assert aimdo.init_device(device)
+torch.empty(1, device="cuda")
+cuda_device = torch.device("cuda", device)
+
+free, capacity = torch.cuda.mem_get_info(device)
+model = capacity // 4
+model -= model % CHUNK
+chunks = model // CHUNK
+
+vbar = ModelVBAR(model * 10, device)
+vbar.prioritize()
+allocs = [vbar.alloc(CHUNK) for _ in range(chunks)]
+
+
+def forward(fill=None):
+    faulted = 0
+    for alloc in allocs:
+        if vbar_fault(alloc) is None:
+            continue
+        if fill is not None:
+            comfy_aimdo.torch.aimdo_to_tensor(alloc, cuda_device).fill_(fill)
+        vbar_unpin(alloc)
+        faulted += 1
+    torch.cuda.synchronize()
+    return faulted
+
+
+forward(1)
+assert vbar.loaded_size() == model
+
+free_now, _ = torch.cuda.mem_get_info(device)
+headroom = free_now + aimdo.get_total_vram_usage() - model // 2
+budget = capacity - headroom
+aimdo.set_simple_vram_headroom(headroom)
+assert aimdo.get_simple_vram_headroom() == headroom
+
+faulted = forward()
+pressed = vbar.loaded_size()
+assert faulted < chunks
+assert pressed <= budget + PAGE
+assert pressed < model * 0.9
+
+spill = torch.empty(min(model // 4, budget // 2), dtype=torch.uint8, device=cuda_device)
+torch.cuda.synchronize()
+forward()
+assert vbar.loaded_size() <= pressed - spill.numel() + 2 * PAGE
+del spill
+torch.cuda.empty_cache()
+
+aimdo.set_simple_vram_headroom(DEFAULT_HEADROOM)
+vbar.prioritize()
+forward()
+assert vbar.loaded_size() == model
+
+del allocs
+del vbar
+gc.collect()
+torch.cuda.synchronize()
+aimdo.deinit()
+print("simple_vram_headroom runtime test passed")


### PR DESCRIPTION
The simple headroom is a process global read on every budget check (`src/plat.h` `budget_deficit`, `src/model-vbar.c` fault path), so it can already be changed while running, but the Python module never exposed that. The only runtime path is calling `init()` again, which [ComfyUI-ReservedVRAM](https://github.com/Windecay/ComfyUI-ReservedVRAM) does at node time ([nodes.py:68-84](https://github.com/Windecay/ComfyUI-ReservedVRAM/blob/be93b9375ebe/nodes.py#L68-L84)); it works, but it is a side door that resets every other `init()` argument on the way through, and a planned change in ComfyUI will write the same value once per model load to forward its runtime reserve, today seeded once at startup ([main.py:70-80](https://github.com/Comfy-Org/ComfyUI/blob/master/main.py#L70-L80), from #14480 there). The first consumer of that forward is [comfy-env](https://github.com/PozzettiAndrea/comfy-env).

Expose `set_simple_vram_headroom()` and `get_simple_vram_headroom()`. The setter applies the bounds check `init_devices()` already applies to the per device headroom; `init()` keeps passing its seed straight to C, so nothing changes for existing callers. Per device belongs with #31, not here.

The docstring states the three things a caller needs: raising takes effect at the next VBAR fault or hooked allocation and is honoured by evicting VBAR pages only; lowering refills nothing until a VBAR is next prioritized, which ComfyUI does at model load; and only the simple term reads it, since the measured poll term keeps its own 256 MB floor and the budget takes the larger of the two.

`tests/simple-vram-headroom-runtime-cuda.py`, RTX 3090, identical on 0.4.13 and this branch: 6016 MiB resident at the default headroom; a 20637 MiB runtime headroom leaves 3456 MiB resident with 20 of 47 chunks refused at the next fault; a 1504 MiB torch tensor is counted and VBAR pages make way for it; back to 256 MiB plus `prioritize()` refills to 6016 MiB.

### Contribution Agreement
- [x] I agree that my contributions are licensed under the GPLv3.
- [x] I grant **Comfy Org** the rights to relicense these contributions as outlined in [CONTRIBUTING.md](./CONTRIBUTING.md).
