### PR TITLE
Fix VBAR reservation using requested size instead of VRAM capacity

### DIFF
--- a/comfy_aimdo/model_vbar.py
+++ b/comfy_aimdo/model_vbar.py
@@ -48,8 +48,12 @@ if lib is not None:
 
 class ModelVBAR:
     def __init__(self, size, device):
+        size = int(size)
+        max_size = ctypes.c_uint64(-1).value - (32 * 1024 ** 2 - 1)
+        if size <= 0 or size > max_size:
+            raise ValueError("Invalid VBAR size")
         self._devctx = control.get_devctx(device)
-        self._ptr = lib.vbar_allocate(self._devctx, int(size), device)
+        self._ptr = lib.vbar_allocate(self._devctx, size, device)
         if not self._ptr:
             raise MemoryError("VBAR allocation failed")
         self.device = device

--- a/src/model-vbar.c
+++ b/src/model-vbar.c
@@ -225,11 +225,18 @@ void *vbar_allocate(void *devctx, uint64_t size, int device) {
     log(DEBUG, "%s (start): size=%zuM, device=%d\n", __func__, size / M, device);
     vbars_dirty = true;
 
-    /* Reserve the window the caller asked for. vram_capacity is physical VRAM and
-     * says nothing about how much of the window gets sub-allocated, so clamping to
-     * it made an oversized request reserve capacity worth of address space.
+    /* Reserve the window the caller asked for. Physical VRAM capacity does not
+     * limit how much virtual address space the model may sub-allocate.
      */
+    if (!size || size > UINT64_MAX - (VBAR_PAGE_SIZE - 1)) {
+        log(AIMDO_LOG_ERROR, "Invalid VBAR size: %llu\n", (ull)size);
+        return NULL;
+    }
     size_t nr_pages = VBAR_GET_PAGE_NR_UP(size);
+    if (nr_pages > (SIZE_MAX - sizeof(*mv)) / sizeof(mv->residency_map[0])) {
+        log(AIMDO_LOG_ERROR, "VBAR residency map is too large\n");
+        return NULL;
+    }
     size = (uint64_t)nr_pages * VBAR_PAGE_SIZE;
 
     if (!(mv = calloc(1, sizeof(*mv) + nr_pages * sizeof(mv->residency_map[0])))) {

--- a/src/model-vbar.c
+++ b/src/model-vbar.c
@@ -225,11 +225,11 @@ void *vbar_allocate(void *devctx, uint64_t size, int device) {
     log(DEBUG, "%s (start): size=%zuM, device=%d\n", __func__, size / M, device);
     vbars_dirty = true;
 
+    /* Reserve the window the caller asked for. vram_capacity is physical VRAM and
+     * says nothing about how much of the window gets sub-allocated, so clamping to
+     * it made an oversized request reserve capacity worth of address space.
+     */
     size_t nr_pages = VBAR_GET_PAGE_NR_UP(size);
-    size_t nr_pages_max = VBAR_GET_PAGE_NR(vram_capacity);
-    if (nr_pages_max < nr_pages) {
-        nr_pages = nr_pages_max;
-    }
     size = (uint64_t)nr_pages * VBAR_PAGE_SIZE;
 
     if (!(mv = calloc(1, sizeof(*mv) + nr_pages * sizeof(mv->residency_map[0])))) {


### PR DESCRIPTION
 ## Summary

  Fix `--enable-dynamic-vram` crash on Windows ROCm caused by GPU virtual address space exhaustion in comfy-aimdo VBAR allocation.

  ## Problem

  On Windows ROCm, `--enable-dynamic-vram` crashes with:

      OSError: exception: access violation reading 0x00000000000000E0

  `vbar_allocate` clamps the virtual address reservation to `vram_capacity` (physical VRAM). When a model is larger than ~1/10 of device capacity, the clamp reserves the *entire device capacity* as address space instead of the requested size.

  On large-VRAM devices, the clamped reservations can consume several times the actual model size in GPU virtual address space. Once exhausted, `hipMemAddressReserve` does not return `hipErrorOutOfMemory` — it access-violates at `0xE0`.

  ## Fix

  Remove the `vram_capacity` clamp. Reserve exactly the page-rounded size the caller requested.

  This PR should land together with the https://github.com/Comfy-Org/ComfyUI/pull/16174 that sizes VBARs  from `compute-dtype` weight spans instead of `model_size() * 10`.